### PR TITLE
fix:u-text mode price text not extend type color

### DIFF
--- a/uni_modules/uview-ui/components/u-text/u-text.vue
+++ b/uni_modules/uview-ui/components/u-text/u-text.vue
@@ -9,7 +9,7 @@
 	    @tap="clickHandler"
 	>
 		<text
-		    class="u-text__price"
+		    :class="['u-text__price', type && `u-text__value--${type}`]"
 		    v-if="mode === 'price'"
 		    :style="[valueStyle]"
 		>￥</text>


### PR DESCRIPTION
修复u-text组件 price 模式 ￥符号没有继承 模式颜色