### PR TITLE
 Router增加toNvue方法、box-shadow增加條件判斷、日曆修改mode=range返回內容

### DIFF
--- a/pages/componentsB/countDown/countDown.nvue
+++ b/pages/componentsB/countDown/countDown.nvue
@@ -224,7 +224,9 @@
 				/* #endif */
 				justify-content: center;
 				align-items: center;
+				/* #ifndef APP-NVUE */
 				box-shadow: 1px 1px 4px rgba(155, 191, 255, .7);
+				/* #endif */
 			}
 
 			&__grid-text {

--- a/uni_modules/uview-ui/components/u-calendar/u-calendar.vue
+++ b/uni_modules/uview-ui/components/u-calendar/u-calendar.vue
@@ -183,6 +183,7 @@
 				if(!this.showConfirm) {
 					// 在不需要确认按钮的情况下，如果为单选，或者范围多选且已选长度大于2，则直接进行返还
 					if (this.mode === 'multiple' || this.mode === 'single' || this.mode === 'range' && this.selected.length >= 2) {
+						//range下返回數組為 第一天，最後一天，其餘模式按選擇的天數返回數組
 						this.$emit('confirm', this.mode == 'range' ? [this.selected[0],this.selected[this.selected.length-1]] : this.selected)
 					}
 				}
@@ -197,6 +198,7 @@
 			},
 			// 点击确定按钮
 			confirm() {
+				//range下返回數組為 第一天，最後一天，其餘模式按選擇的天數返回數組
 				if (!this.buttonDisabled) {
 					this.$emit('confirm', this.mode == 'range' ? [this.selected[0],this.selected[this.selected.length-1]] : this.selected)
 				}

--- a/uni_modules/uview-ui/components/u-calendar/u-calendar.vue
+++ b/uni_modules/uview-ui/components/u-calendar/u-calendar.vue
@@ -183,7 +183,7 @@
 				if(!this.showConfirm) {
 					// 在不需要确认按钮的情况下，如果为单选，或者范围多选且已选长度大于2，则直接进行返还
 					if (this.mode === 'multiple' || this.mode === 'single' || this.mode === 'range' && this.selected.length >= 2) {
-						this.$emit('confirm', this.selected)
+						this.$emit('confirm', this.mode == 'range' ? [this.selected[0],this.selected[this.selected.length-1]] : this.selected)
 					}
 				}
 			},
@@ -198,7 +198,7 @@
 			// 点击确定按钮
 			confirm() {
 				if (!this.buttonDisabled) {
-					this.$emit('confirm', this.selected)
+					this.$emit('confirm', this.mode == 'range' ? [this.selected[0],this.selected[this.selected.length-1]] : this.selected)
 				}
 			},
 			// 设置月份数据

--- a/uni_modules/uview-ui/components/u-car-keyboard/u-car-keyboard.vue
+++ b/uni_modules/uview-ui/components/u-car-keyboard/u-car-keyboard.vue
@@ -254,7 +254,9 @@
 			/* #endif */
 
 			&__inner-wrapper {
+				/* #ifndef APP-NVUE */
 				box-shadow: $u-car-keyboard-button-inner-box-shadow;
+				/* #endif */
 				margin: $u-car-keyboard-button-inner-margin;
 				border-radius: $u-car-keyboard-button-border-radius;
 
@@ -282,7 +284,10 @@
 					@include flex;
 					justify-content: center;
 					align-items: center;
+					
+					/* #ifndef APP-NVUE */
 					box-shadow: $u-car-keyboard-button-inner-box-shadow;
+					/* #endif */
 				}
 
 				&__left {

--- a/uni_modules/uview-ui/components/u-number-keyboard/u-number-keyboard.vue
+++ b/uni_modules/uview-ui/components/u-number-keyboard/u-number-keyboard.vue
@@ -158,7 +158,9 @@
 		padding: $u-number-keyboard-padding;
 
 		&__button-wrapper {
+			/* #ifndef APP-NVUE */
 			box-shadow: $u-number-keyboard-button-box-shadow;
+			/* #endif */
 			margin: $u-number-keyboard-button-margin;
 			border-top-left-radius: $u-number-keyboard-button-border-top-left-radius;
 			border-top-right-radius: $u-number-keyboard-button-border-top-right-radius;

--- a/uni_modules/uview-ui/components/u-switch/u-switch.vue
+++ b/uni_modules/uview-ui/components/u-switch/u-switch.vue
@@ -149,7 +149,9 @@
 			border-radius: 100px;
 			background-color: #fff;
 			border-radius: 100px;
+			/* #ifndef APP-NVUE */
 			box-shadow: 1px 1px 1px 0 rgba(0, 0, 0, 0.25);
+			/* #endif */
 			transition-property: transform;
 			transition-duration: 0.4s;
 			transition-timing-function: cubic-bezier(0.3, 1.05, 0.4, 1.05);

--- a/uni_modules/uview-ui/libs/util/route.js
+++ b/uni_modules/uview-ui/libs/util/route.js
@@ -118,6 +118,33 @@ class Router {
                 delta
             })
         }
+		//增加nvue預加載跳轉，解決nvue直接跳轉時若背景主題不一致時產生閃爍問題，先預加載，再跳轉，再取消預加載。
+        if (config.type == 'toNvue') {
+			let preloadPageLoading = setTimeout(() => {
+				uni.showLoading({
+				  mask: true
+				})
+			}, 350)
+			uni.preloadPage({
+				url:url,
+				complete:()=>{
+					setTimeout(() => {
+						clearTimeout(preloadPageLoading)
+						uni.hideLoading()
+						uni.navigateTo({
+							url,
+							animationType,
+							animationDuration,
+						    complete:()=>{
+								uni.unPreloadPage({
+								  url
+								})
+							}
+						})
+					}, 350)
+				}
+			});
+        }
     }
 }
 


### PR DESCRIPTION
1、Router增加toNvue方法，跳轉nvue時進行預加載，加載完成後進行跳轉，跳轉後取消預加載，防止跳轉nvue背景或主題不一致導致閃爍透明等現象；
2、AOS中nvue頁面存在box-shadow屬性會導致二級頁面透明或狀態欄閃爍（自定義導航欄）
3、日曆中如mode為range，返回的為[開始日期，結束日期]，其餘模式的不變。