### PR TITLE
fix: 当picker组件的lastIndex数组为空数组的时候无法正确判断当前变化的列

### DIFF
--- a/uni_modules/uview-ui/components/u-picker/u-picker.vue
+++ b/uni_modules/uview-ui/components/u-picker/u-picker.vue
@@ -144,7 +144,7 @@ export default {
 			// 通过对比前后两次的列索引，得出当前变化的是哪一列
 			for (let i = 0; i < value.length; i++) {
 				let item = value[i]
-				if (item !== this.lastIndex[i]) {
+				if (item !== (this.lastIndex[i] || 0)) { // 把undefined转为合法假值0
 					// 设置columnIndex为当前变化列的索引
 					columnIndex = i
 					// index则为变化列中的变化项的索引


### PR DESCRIPTION
处理undefined的情况，将原有的this.lastIndex[i]更改为(this.lastIndex[i] || 0)