### PR TITLE
fix: 修复时间列选择器在传入的value为字符串的时候时间显示错误及数组索引异常的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-datetime-picker/u-datetime-picker.vue
+++ b/uni_modules/uview-ui/components/u-datetime-picker/u-datetime-picker.vue
@@ -73,7 +73,7 @@
 		watch: {
 			show(newValue, oldValue) {
 				if (newValue) {
-					this.updateColumnValue(this.value)
+					this.updateColumnValue(+this.value)
 				}
 			},
 			propsChange() {


### PR DESCRIPTION
this.value 修改为 +this.value，即通过一元运算符的方式完成隐式类型转换，如果是因为value不是合法的数字字符串而引起的NaN异常则让vue抛出使用户自己处理