### PR TITLE
fix: swipe-action组件在vue项目里无法默认隐藏按钮组

### DIFF
--- a/uni_modules/uview-ui/components/u-swipe-action-item/u-swipe-action-item.vue
+++ b/uni_modules/uview-ui/components/u-swipe-action-item/u-swipe-action-item.vue
@@ -28,7 +28,7 @@
 			</slot>
 		</view>
 		<!-- #ifdef APP-VUE || MP-WEIXIN || H5 || MP-QQ -->
-		<view class="u-swipe-action-item__content" @touchstart="wxs.touchstart" @touchmove="wxs.touchmove"
+		<view ref="uSwiperActionItemContent" class="u-swipe-action-item__content" @touchstart="wxs.touchstart" @touchmove="wxs.touchmove"
 			@touchend="wxs.touchend" :status="status" :change:status="wxs.statusChange" :size="size"
 			:change:size="wxs.sizeChange">
 			<!-- #endif -->
@@ -101,6 +101,11 @@
 		},
 		mounted() {
 			this.init()
+			if(!this.show) {
+				  // 用户不想默认显示
+				  let $el = this.$refs.uSwiperActionItemContent.$el; // 获取真实DOM节点
+				  $el.style="transition: none 0s ease 0s; transform: translateX(0px);" // 添加样式
+			}
 		},
 		methods: {
 			init() {


### PR DESCRIPTION
究其原因是transform动画属性没有在初始状态下就存在，因为目前组件的行为是忽略show属性且默认显示的，所以单独处理!show(用户不想默认显示)的情况即可，解决方案便是直接给DOM节点添加transform属性

close #111 