### PR TITLE
fix：当 u-form 的 borderBottom 为 ture，errorType 为 none 或 toast ，表单校验出错-正确 表单校验正确->出错的时候 ，u-form-item 的下横线 u-line 高度抖动问题

### DIFF
--- a/uni_modules/uview-ui/components/u-form-item/u-form-item.vue
+++ b/uni_modules/uview-ui/components/u-form-item/u-form-item.vue
@@ -68,7 +68,7 @@
 		<u-line
 			v-if="borderBottom"
 			:color="message && parentData.errorType === 'border-bottom' ? $u.color.error : $u.props.line.color"
-			:customStyle="`margin-top: ${message ? '5px' : 0}`"
+			:customStyle="`margin-top: ${ message && ( parentData.errorType === 'border-bottom' || parentData.errorType === 'message' ) ? '5px' : 0}`"
 		></u-line>
 	</view>
 </template>


### PR DESCRIPTION
fix：当 u-form 的 borderBottom 为 ture，errorType 为 none 或 toast ，表单校验出错-正确 表单校验正确->出错的时候 ，u-form-item 的下横线 u-line 高度抖动问题
![动画](https://user-images.githubusercontent.com/66937093/144384035-8a47a28c-cad8-4de0-8fa5-1e4ae8b1045e.gif)

