### PR TITLE
fix: u-text金额模式传0报错

### DIFF
--- a/uni_modules/uview-ui/components/u-text/value.js
+++ b/uni_modules/uview-ui/components/u-text/value.js
@@ -11,7 +11,9 @@ export default {
             // 价格类型
             if (mode === 'price') {
                 // 如果text不为金额进行提示
-                !uni.$u.test.amount(text) && uni.$u.error('金额模式下，text参数需要为金额格式')
+                if (!/^\d+(\.\d+)?$/.test(text)) {
+                    uni.$u.error('金额模式下，text参数需要为金额格式');
+                }
                 // 进行格式化，判断用户传入的format参数为正则，或者函数，如果没有传入format，则使用默认的金额格式化处理
                 if (uni.$u.test.func(format)) {
                     // 如果用户传入的是函数，使用函数格式化


### PR DESCRIPTION
修改用来进行校验的正则表达式，Github历史文件比对有误，实际修改的为14行至16行