### PR TITLE
车辆键盘增加指定中英文键盘的参数

### DIFF
--- a/uni_modules/uview-ui/components/u-car-keyboard/props.js
+++ b/uni_modules/uview-ui/components/u-car-keyboard/props.js
@@ -9,6 +9,11 @@ export default {
         autoChange: {
             type: Boolean,
             default: false
+        },
+        // 指定使用中文输入法或英文输入法
+        abc: {
+            type: Boolean,
+            default: false
         }
     }
 }

--- a/uni_modules/uview-ui/components/u-car-keyboard/u-car-keyboard.vue
+++ b/uni_modules/uview-ui/components/u-car-keyboard/u-car-keyboard.vue
@@ -83,8 +83,6 @@
 		mixins: [uni.$u.mpMixin, uni.$u.mixin, props],
 		data() {
 			return {
-				// 车牌输入时，abc=true为输入车牌号码，bac=false为输入省份中文简称
-				abc: false
 			};
 		},
 		computed: {

--- a/uni_modules/uview-ui/components/u-keyboard/props.js
+++ b/uni_modules/uview-ui/components/u-keyboard/props.js
@@ -79,6 +79,11 @@ export default {
         autoChange: {
             type: Boolean,
             default: uni.$u.props.keyboard.autoChange
+        },
+        // 指定使用中文输入法还是英文输入法
+        abc: {
+            type: Boolean,
+            default: uni.$u.props.keyboard.abc
         }
     }
 }

--- a/uni_modules/uview-ui/components/u-keyboard/u-keyboard.vue
+++ b/uni_modules/uview-ui/components/u-keyboard/u-keyboard.vue
@@ -59,6 +59,7 @@
 				<u-car-keyboard
 				    :random="random"
 					:autoChange="autoChange"
+                    :abc="abc"
 				    @backspace="backspace"
 				    @change="change"
 				></u-car-keyboard>
@@ -82,6 +83,8 @@
 	 * @property {Boolean}			showCancel			是否显示工具条左边的"取消"按钮 （默认 true ）
 	 * @property {Boolean}			showConfirm			是否显示工具条右边的"完成"按钮（ 默认 true ）
 	 * @property {Boolean}			random				是否打乱键盘按键的顺序 （默认 false ）
+	 * @property {Boolean}			autoChange			输入一个中文后，是否自动切换到英文 （默认 false ）
+	 * @property {Boolean}			abc 				指定使用中文输入法还是英文输入法 （默认 false ）
 	 * @property {Boolean}			safeAreaInsetBottom	是否开启底部安全区适配 （默认 true ）
 	 * @property {Boolean}			closeOnClickOverlay	是否允许点击遮罩收起键盘 （默认 true ）
 	 * @property {Boolean}			show				控制键盘的弹出与收起（默认 false ）


### PR DESCRIPTION
u-keyboard 组件虽然有 autoChange 参数，但是自由度还是不够高，如果能自己指定默认显示的是中文键盘还是英文键盘是很有帮助的。