### PR TITLE
fix: numberBox的事件中不包含name参数

### DIFF
--- a/uni_modules/uview-ui/components/u-number-box/u-number-box.vue
+++ b/uni_modules/uview-ui/components/u-number-box/u-number-box.vue
@@ -241,7 +241,10 @@
 			// },
 			// 输入框活动焦点
 			onFocus(event) {
-				this.$emit('focus', event.detail)
+				this.$emit('focus', {
+					...event.detail,
+					name: this.name,
+				})
 			},
 			// 输入框失去焦点
 			onBlur(event) {
@@ -282,7 +285,10 @@
 						this.$forceUpdate()
 					})
 				}
-				this.$emit('change', value);
+				this.$emit('change', {
+					value,
+					name: this.name,  
+				});
 			},
 			onChange() {
 				const {


### PR DESCRIPTION
在onFocus和emitChange中补上name参数

close #133