### PR TITLE
u-tabs修复底部线条不显示问题

### DIFF
--- a/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
+++ b/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
@@ -312,7 +312,7 @@
 
 			&__nav {
 				@include flex;
-
+				position: relative;
 				&__item {
 					padding: 0 11px;
 					@include flex;


### PR DESCRIPTION
原因：父view缺少position: relative;属性