### PR TITLE
完善u-index-list，使其默认支持#符号

### DIFF
--- a/pages/componentsC/indexList/indexList.nvue
+++ b/pages/componentsC/indexList/indexList.nvue
@@ -52,6 +52,7 @@
 		for (let i = 0; i < 26; i++) {
 			indexList.push(String.fromCharCode(charCodeOfA + i))
 		}
+		indexList.push('_')
 		return indexList
 	}
 	export default {

--- a/uni_modules/uview-ui/components/u-index-anchor/u-index-anchor.vue
+++ b/uni_modules/uview-ui/components/u-index-anchor/u-index-anchor.vue
@@ -16,7 +16,7 @@
 				fontSize: $u.addUnit(size),
 				color: color
 			}"
-		>{{ text }}</text>
+		>{{ text == '_' ? '#' : text}}</text>
 	</view>
 	<!-- #ifdef APP-NVUE -->
 	</header>
@@ -65,7 +65,7 @@
 					return uni.$u.error('u-index-anchor必须要搭配u-index-item组件使用')
 				}
 				// 设置u-index-item的id为anchor的text标识符，因为非nvue下滚动列表需要依赖scroll-view滚动到元素的特性
-				indexListItem.id = this.text
+				indexListItem.id = this.text == '#' ? '_' : this.text
 				// #endif
 			}
 		},

--- a/uni_modules/uview-ui/components/u-index-list/u-index-list.vue
+++ b/uni_modules/uview-ui/components/u-index-list/u-index-list.vue
@@ -64,7 +64,7 @@
 				<text
 					class="u-index-list__letter__item__index"
 					:style="{color: activeIndex === index ? '#fff' : inactiveColor}"
-				>{{ item }}</text>
+				>{{ item == '_' ? '#' : item }}</text>
 			</view>
 		</view>
 		<u-transition
@@ -85,7 +85,7 @@
 					width: $u.addUnit(indicatorHeight)
 				}"
 			>
-				<text class="u-index-list__indicator__text">{{ uIndexList[activeIndex] }}</text>
+				<text class="u-index-list__indicator__text">{{ uIndexList[activeIndex] == '_' ? '#' : uIndexList[activeIndex] }}</text>
 			</view>
 		</u-transition>
 	</view>
@@ -98,6 +98,7 @@
 		for (let i = 0; i < 26; i++) {
 			indexList.push(String.fromCharCode(charCodeOfA + i));
 		}
+		indexList.push('_')
 		return indexList;
 	}
 	import props from './props.js';


### PR DESCRIPTION
给u-index-list的indexList添加了_符号，使用#代替_页面展示，但id处是以_展示，最终使其支持#符号