### PR TITLE
fix: 修复u-avatar 导致打包app、H5时候报错

### DIFF
--- a/uni_modules/uview-ui/components/u-avatar/u-avatar.vue
+++ b/uni_modules/uview-ui/components/u-avatar/u-avatar.vue
@@ -10,6 +10,7 @@
 		@tap.stop="clickHandler"
 	>
 		<slot>
+			<!-- #ifdef MP-WEIXIN || MP-QQ || MP-BAIDU  -->
 			<open-data
 				v-if="mpAvatar && allowMp"
 				type="userAvatarUrl"
@@ -18,6 +19,12 @@
 					height: $u.addUnit(size)
 				}]"
 			/>
+			<!-- #endif -->
+			<!-- #ifndef MP-WEIXIN && MP-QQ && MP-BAIDU  -->
+			<template v-if="mpAvatar && allowMp">
+				
+			</template>
+			<!-- #endif -->
 			<u-icon
 				v-else-if="icon"
 				:name="icon"


### PR DESCRIPTION
打包app、H5时候 提示 文件查找失败:'uni-view/components/open-data' open-data不支持app和h5