### PR TITLE
fix：修复u--input的前置/后置图标在微信小程序失效的问题 修复ActionSheet操作菜单 round无效

### DIFF
--- a/pages/componentsB/actionSheet/actionSheet.nvue
+++ b/pages/componentsB/actionSheet/actionSheet.nvue
@@ -55,7 +55,7 @@
 		    :show="show4"
 		    @close="show4 = false"
 			title="标题位置"
-			round
+			:round="round"
 		>
 			<u--text
 			    type="content"
@@ -82,6 +82,7 @@
 				show3: false,
 				show4: false,
 				show5: false,
+				round: 10,
 				actions0: [{
 						name: '选项1',
 					},

--- a/uni_modules/uview-ui/components/u--input/u--input.vue
+++ b/uni_modules/uview-ui/components/u--input/u--input.vue
@@ -44,8 +44,8 @@
 		@clear="$emit('clear')"
 		@click="$emit('click')"
 	>
-		<slot name="prefix" slot="prefix"></slot>
-		<slot name="suffix" slot="suffix"></slot>
+		<slot name="prefix"></slot>
+		<slot name="suffix"></slot>
 	</uvInput>
 </template>
 

--- a/uni_modules/uview-ui/components/u--input/u--input.vue
+++ b/uni_modules/uview-ui/components/u--input/u--input.vue
@@ -44,8 +44,14 @@
 		@clear="$emit('clear')"
 		@click="$emit('click')"
 	>
+		<!-- #ifdef MP -->
 		<slot name="prefix"></slot>
 		<slot name="suffix"></slot>
+		<!-- #endif -->
+		<!-- #ifndef MP -->
+		<slot name="prefix" slot="prefix"></slot>
+		<slot name="suffix" slot="suffix"></slot>
+		<!-- #endif -->
 	</uvInput>
 </template>
 

--- a/uni_modules/uview-ui/components/u-action-sheet/props.js
+++ b/uni_modules/uview-ui/components/u-action-sheet/props.js
@@ -45,9 +45,9 @@ export default {
             type: Boolean,
             default: uni.$u.props.actionSheet.closeOnClickOverlay
         },
-        // 是否显示圆角 (默认false)
+        // 是否显示圆角 (默认0)
         round: {
-            type: Boolean,
+            type: [Boolean, String, Number],
             default: uni.$u.props.actionSheet.round
         }
     }

--- a/uni_modules/uview-ui/components/u-action-sheet/u-action-sheet.vue
+++ b/uni_modules/uview-ui/components/u-action-sheet/u-action-sheet.vue
@@ -125,7 +125,7 @@
 	 * @property {Boolean}			safeAreaInsetBottom	处理底部安全区 （默认 true ）
 	 * @property {String}			openType			小程序的打开方式 (contact | launchApp | getUserInfo | openSetting ｜getPhoneNumber ｜error )
 	 * @property {Boolean}			closeOnClickOverlay	点击遮罩是否允许关闭  (默认 true )
-	 * @property {Boolean}			round				是否显示圆角  (默认 false )
+	 * @property {String | Number}	round				圆角值（默认 0）
 	 * @property {String}			lang				指定返回用户信息的语言，zh_CN 简体中文，zh_TW 繁体中文，en 英文
 	 * @property {String}			sessionFrom			会话来源，openType="contact"时有效
 	 * @property {String}			sendMessageTitle	会话内消息卡片标题，openType="contact"时有效

--- a/uni_modules/uview-ui/libs/config/props/actionSheet.js
+++ b/uni_modules/uview-ui/libs/config/props/actionSheet.js
@@ -20,6 +20,6 @@ export default {
         safeAreaInsetBottom: true,
         openType: '',
         closeOnClickOverlay: true,
-        round: false
+        round: 0
     }
 }


### PR DESCRIPTION
H5 微信小程序 ios（7plus）    
示例 vue  nvue 都测过了