### PR TITLE
修复微信小程序环境中tabbar组件开启safeAreaInsetBottom属性后，placeholder高度填充不正确

### DIFF
--- a/uni_modules/uview-ui/components/u-tabbar/u-tabbar.vue
+++ b/uni_modules/uview-ui/components/u-tabbar/u-tabbar.vue
@@ -94,8 +94,9 @@
 				// 延时一定时间
 				await uni.$u.sleep(20)
 				// #ifndef APP-NVUE
-				this.$uGetRect('.u-tabbar__content').then(size => {
-					this.placeholderHeight = 50
+				this.$uGetRect('.u-tabbar__content').then(({height = 0}) => {
+					// 修复IOS safearea bottom 未填充高度
+					this.placeholderHeight = height
 				})
 				// #endif
 

--- a/uni_modules/uview-ui/components/u-tabbar/u-tabbar.vue
+++ b/uni_modules/uview-ui/components/u-tabbar/u-tabbar.vue
@@ -94,7 +94,7 @@
 				// 延时一定时间
 				await uni.$u.sleep(20)
 				// #ifndef APP-NVUE
-				this.$uGetRect('.u-tabbar__content').then(({height = 0}) => {
+				this.$uGetRect('.u-tabbar__content').then(({height = 50}) => {
 					// 修复IOS safearea bottom 未填充高度
 					this.placeholderHeight = height
 				})


### PR DESCRIPTION
之前的源代码中placeholder的高度是写死的50，如果开启了safeAreaInsetBottom，这个高度是不准确的，