### PR TITLE
fix: input的placeholder在小程序端默认显示为true

### DIFF
--- a/uni_modules/uview-ui/libs/config/props/input.js
+++ b/uni_modules/uview-ui/libs/config/props/input.js
@@ -18,7 +18,7 @@ export default {
 		clearable: false,
 		password: false,
 		maxlength: -1,
-		placeholder: '',
+		placeholder: null,
 		placeholderClass: 'input-placeholder',
 		placeholderStyle: 'color: #c0c4cc',
 		showWordLimit: false,


### PR DESCRIPTION
此为小程序的原生input的问题，当传的值为空字符串的时候占位符显示为一个true。解决方案为显式的给null。