### PR TITLE
fix(u-code-input): 修复 maxlength 属性值为 String 类型时显示异常

### DIFF
--- a/uni_modules/uview-ui/components/u-code-input/u-code-input.vue
+++ b/uni_modules/uview-ui/components/u-code-input/u-code-input.vue
@@ -84,7 +84,7 @@
 		computed: {
 			// 根据长度，循环输入框的个数，因为头条小程序数值不能用于v-for
 			codeLength() {
-				return new Array(this.maxlength)
+				return new Array(Number(this.maxlength))
 			},
 			// 循环item的样式
 			itemStyle() {


### PR DESCRIPTION
问题如下：

```html
<u-code-input
  maxlength="5" // 显示异常，只显示一个输入格
  value="46821"
></u-code-input>
```

```html
<u-code-input
  :maxlength="5" // 显示正常
  value="46821"
></u-code-input>
```