### PR TITLE
fix:修复日历设置时间区间大于monthNum时，月数为monthNum的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-calendar/u-calendar.vue
+++ b/uni_modules/uview-ui/components/u-calendar/u-calendar.vue
@@ -248,7 +248,7 @@ export default {
             // 最大最小月份之间的共有多少个月份，
             const months = uni.$u.range(
                 1,
-                this.monthNum,
+                Math.max(this.monthNum,this.getMonths(minDate, maxDate)),
                 this.getMonths(minDate, maxDate)
             )
             // 先清空数组


### PR DESCRIPTION
如题，目前在官方示例项目中也有出现此问题