### PR TITLE
添加倒计时组件的顺计时功能

### DIFF
--- a/pages/componentsB/countDown/countDown.nvue
+++ b/pages/componentsB/countDown/countDown.nvue
@@ -14,6 +14,19 @@
 			</view>
 		</view>
 		<view class="u-demo-block">
+			<text class="u-demo-block__title">基础用法(顺计时)</text>
+			<view class="u-demo-block__content">
+				<u-count-down
+				    :startTime="startTime"
+				    format="HH:mm:ss"
+					:isCountDown="false"
+				    autoStart
+					millisecond
+				>
+				</u-count-down>
+			</view>
+		</view>
+		<view class="u-demo-block">
 			<text class="u-demo-block__title">自定义格式</text>
 			<view class="u-demo-block__content">
 				<u-count-down
@@ -126,6 +139,11 @@
 		data() {
 			return {
 				timeData: {},
+			}
+		},
+		computed:{
+			startTime(){
+				return new Date().getTime();
 			}
 		},
 		onLoad() {

--- a/uni_modules/uview-ui/components/u-count-down/props.js
+++ b/uni_modules/uview-ui/components/u-count-down/props.js
@@ -5,6 +5,11 @@ export default {
             type: [String, Number],
             default: uni.$u.props.countDown.time
         },
+        // 顺计时开始时间，单位ms （默认 new Date().getTime() 
+        startTime: {
+            type: [String, Number],
+            default: uni.$u.props.countDown.startTime
+        },
         // 时间格式，DD-日，HH-时，mm-分，ss-秒，SSS-毫秒
         format: {
             type: String,
@@ -19,6 +24,10 @@ export default {
         millisecond: {
             type: Boolean,
             default: uni.$u.props.countDown.millisecond
-        }
+        },
+		isCountDown:{
+			type: Boolean,
+			default: uni.$u.props.countDown.isCountDown
+		}
     }
 }

--- a/uni_modules/uview-ui/components/u-count-down/u-count-down.vue
+++ b/uni_modules/uview-ui/components/u-count-down/u-count-down.vue
@@ -18,9 +18,11 @@
 	 * @description 该组件一般使用于某个活动的截止时间上，通过数字的变化，给用户明确的时间感受，提示用户进行某一个行为操作。
 	 * @tutorial https://uviewui.com/components/countDown.html
 	 * @property {String | Number}	time		倒计时时长，单位ms （默认 0 ）
+	 * @property {String | Number}	startTime	顺计时开始时间，单位ms （默认 new Date().getTime() ）
 	 * @property {String}			format		时间格式，DD-日，HH-时，mm-分，ss-秒，SSS-毫秒  （默认 'HH:mm:ss' ）
 	 * @property {Boolean}			autoStart	是否自动开始倒计时 （默认 true ）
 	 * @property {Boolean}			millisecond	是否展示毫秒倒计时 （默认 false ）
+	 * @property {Boolean}			isCountDown	是否倒计时 （默认 true,如果是false，就是顺计时 ）
 	 * @event {Function} finish 倒计时结束时触发 
 	 * @event {Function} change 倒计时变化时触发 
 	 * @event {Function} start	开始倒计时
@@ -101,8 +103,12 @@
 			},
 			// 获取剩余的时间
 			getRemainTime() {
-				// 取最大值，防止出现小于0的剩余时间值
-				return Math.max(this.endTime - Date.now(), 0)
+				if(this.isCountDown){
+					// 取最大值，防止出现小于0的剩余时间值
+					return Math.max(this.endTime - Date.now(), 0)
+				}else{
+					return Math.max(Date.now()-this.startTime, 0)
+				}
 			},
 			// 设置剩余的时间
 			setRemainTime(remain) {
@@ -113,7 +119,7 @@
 				// 得出格式化后的时间
 				this.formattedTime = parseFormat(this.format, timeData)
 				// 如果时间已到，停止倒计时
-				if (remain <= 0) {
+				if (remain <= 0 && this.isCountDown) {
 					this.pause()
 					this.$emit('finish')
 				}

--- a/uni_modules/uview-ui/libs/config/props/countDown.js
+++ b/uni_modules/uview-ui/libs/config/props/countDown.js
@@ -9,10 +9,12 @@
  */
 export default {
     // u-count-down 计时器组件
-    countDown: {
-        time: 0,
-        format: 'HH:mm:ss',
-        autoStart: true,
-        millisecond: false
-    }
+	countDown: {
+		time: 0,
+		format: 'HH:mm:ss',
+		autoStart: true,
+		millisecond: false,
+		isCountDown:true,
+		startTime:Date.now()
+	}
 }


### PR DESCRIPTION
1.添加倒计时组件的顺计时功能，顺计时需要设置isCountDown为false,startTime为开始计时的时间戳
2.已经测试H5 安卓NVUE 微信小程序
3.示例页面添加顺计时基础用法示例
4.添加属性参数isCountDown（默认值true）和startTime(默认值new Date().getTime()）