### PR TITLE
fix(u-form): 修复clearValidate方法不生效

### DIFF
--- a/uni_modules/uview-ui/components/u-form/u-form.vue
+++ b/uni_modules/uview-ui/components/u-form/u-form.vue
@@ -112,7 +112,7 @@
 				props = [].concat(props);
 				this.children.map((child) => {
 					// 如果u-form-item的prop在props数组中，则清除对应的校验结果信息
-					if (props.includes(child.props)) {
+					if (props.includes(child.prop)) {
 						child.message = null;
 					}
 				});


### PR DESCRIPTION
变量名称书写错误，应为prop，而非props。