### PR TITLE
fix: u-search placeholder 英文显示entity

### DIFF
--- a/uni_modules/uview-ui/components/u-search/u-search.vue
+++ b/uni_modules/uview-ui/components/u-search/u-search.vue
@@ -271,6 +271,7 @@ $u-search-action-margin-left: 5px !default;
 
 			&--placeholder {
 				color: $u-search-input-placeholder-color;
+				line-height: 1.2;
 			}
 		}
 	}


### PR DESCRIPTION
修复placeholder在uniapp中显示p、y不全的问题