### PR TITLE
fix-search

### DIFF
--- a/uni_modules/uview-ui/components/u-search/u-search.vue
+++ b/uni_modules/uview-ui/components/u-search/u-search.vue
@@ -50,16 +50,25 @@
 				}, inputStyle]"
 			/>
 			<view
-			    class="u-search__content__icon u-search__content__close"
-			    v-if="keyword && clearabled && focused"
-			    @tap="clear"
+				class="u-search__content__icon"
+			    :style="{
+					backgroundColor: bgColor,
+					borderTopRightRadius: shape == 'round' ? '100px' : '4px',
+					borderBottomRightRadius: shape == 'round' ? '100px' : '4px',
+					height: height + 'rpx',
+					padding: '0 16rpx',
+				}"
+				v-if="keyword && clearabled && focused"
+				@tap="clear"
 			>
-				<u-icon
-				    name="close"
-				    size="11"
-				    color="#ffffff"
-					customStyle="line-height: 12px"
-				></u-icon>
+				<view class="u-search__content__icon u-search__content__close">
+					<u-icon
+						name="close"
+						size="11"
+						color="#ffffff"
+						customStyle="line-height: 12px"
+					></u-icon>
+				</view>
 			</view>
 		</view>
 		<text
@@ -236,6 +245,7 @@ $u-search-action-margin-left: 5px !default;
 		@include flex;
 		align-items: center;
 		padding: $u-search-content-padding;
+		padding-right: 0;
 		flex: 1;
 		justify-content: space-between;
 		border-width: 1px;


### PR DESCRIPTION
修改理由：
“clearabled”关闭按钮热区过小

场景：
时有点击关闭按钮后，搜索框仅仅失去焦点但未能清空输入框的情况发生，尤其是在搜索栏较小的情况下