### PR TITLE
fix: swiper在current指定非0时缩放有误

### DIFF
--- a/uni_modules/uview-ui/components/u-swiper/u-swiper.vue
+++ b/uni_modules/uview-ui/components/u-swiper/u-swiper.vue
@@ -131,6 +131,12 @@
 				currentIndex: 0
 			}
 		},
+		watch: {
+			current(val, preVal) {
+				if(val === preVal) return;
+				this.currentIndex = val; // 和上游数据关联上
+			}
+		},
 		computed: {
 			itemStyle() {
 				return index => {


### PR DESCRIPTION
作为props传入的current和组件实际使用的currentIndex未关联初始值导致的问题。

close #139