### PR TITLE
feat: u-tabs 组件支持设置滑块背景图

### DIFF
--- a/pages/componentsC/tabs/tabs.nvue
+++ b/pages/componentsC/tabs/tabs.nvue
@@ -72,7 +72,7 @@
 					:list="list4"
 					lineWidth="20"
 					lineHeight="7"
-					:lineColor="`url(${lineBg} 100% 100%)`"
+					:lineColor="`url(${lineBg}) 100% 100%`"
 					:activeStyle="{
 						color: '#303133',
 						fontWeight: 'bold',

--- a/pages/componentsC/tabs/tabs.nvue
+++ b/pages/componentsC/tabs/tabs.nvue
@@ -66,6 +66,28 @@
 			</view>
 		</view>
 		<view class="u-demo-block">
+			<text class="u-demo-block__title">滑块设置背景图</text>
+			<view class="u-demo-block__content">
+				<u-tabs
+					:list="list4"
+					lineWidth="20"
+					lineHeight="7"
+					:lineColor="`url(${lineBg} 100% 100%)`"
+					:activeStyle="{
+						color: '#303133',
+						fontWeight: 'bold',
+						transform: 'scale(1.05)'
+					}"
+					:inactiveStyle="{
+						color: '#606266',
+						transform: 'scale(1)'
+					}"
+					itemStyle="padding-left: 15px; padding-right: 15px; height: 34px;"
+				>
+				</u-tabs>
+			</view>
+		</view>
+		<view class="u-demo-block">
 			<text class="u-demo-block__title">右侧自定义插槽</text>
 			<view class="u-demo-block__content">
 				<u-tabs :list="list1">
@@ -87,10 +109,12 @@
 </template>
 
 <script>
+	const lineBg = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAOCAYAAABdC15GAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAFxSURBVHgBzZNRTsJAEIb/WTW+lpiY+FZPIDew3ABP4GJ8hxsI9zBpOYHeQDwBPQI+mRiRvpLojtPdYhCorQqF/6GdbGd2vvwzBXZcNAt4oj1ANeUoAT5iqkUjbEFLHNmhD1YPEvpZ3ghkGlVDCkc94/BmHMq998I5ONiY1ZBfpKAyuOtgAc5yOEDmYEWNh32BHF91sGHZHmwW4azciN9aQwnz3SJEgOmte+R2tdLprTYoa50mvuomlLpD4Y3oQZnov6D2RzCqI93bWOHaEmAGqQUyRBlZR1WfarcD/EJ2z8DtzDGvsMCwpm8XOCfDUsVOCYhiqRxI/CTQo4UOvjzO7Pow18vfywneuUHHUUxLn55lLw5JFpZ8bEUcY8oXdOLWiHLTxvoGpLqoUmy6dBT15o/ox3znpoycAmxUsiJTbs1cmxeVKp+0zmFIS7bGWiVghC7Vwse8jFKAX9eljh4ggKLLv7uaQvG9/F59Oo2SouxPu7OTCxN/s8wAAAAASUVORK5CYII=";
 	export default {
 		mixins: [uni.$u.mixin],
 		data() {
 			return {
+				lineBg,
 				list1: [{
 					name: '关注',
 				}, {

--- a/uni_modules/uview-ui/components/u-tabs/props.js
+++ b/uni_modules/uview-ui/components/u-tabs/props.js
@@ -35,6 +35,11 @@ export default {
             type: [String, Number],
             default: uni.$u.props.tabs.lineHeight
         },
+        // 滑块背景显示大小，当滑块背景设置为图片时使用
+        lineBgSize: {
+            type: String,
+            default: uni.$u.props.tabs.lineBgSize
+        },
         // 菜单item的样式
         itemStyle: {
             type: [String, Object],

--- a/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
+++ b/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
@@ -54,7 +54,8 @@
 							:style="[{
 									width: $u.addUnit(lineWidth),
 									height: $u.addUnit(lineHeight),
-									backgroundColor: lineColor
+									background: lineColor,
+									backgroundSize: lineBgSize,
 								}]"
 						>
 							<!-- #endif -->
@@ -67,7 +68,8 @@
 										transform: `translate(${lineOffsetLeft}px)`,
 										transitionDuration: `${firstTime ? 0 : duration}ms`,
 										height: $u.addUnit(lineHeight),
-										backgroundColor: lineColor
+										background: lineColor,
+										backgroundSize: lineBgSize,
 									}]"
 							>
 								<!-- #endif -->
@@ -341,7 +343,7 @@
 
 				&__line {
 					height: 3px;
-					background-color: $u-primary;
+					background: $u-primary;
 					width: 30px;
 					position: absolute;
 					bottom: 2px;

--- a/uni_modules/uview-ui/libs/config/props/tabs.js
+++ b/uni_modules/uview-ui/libs/config/props/tabs.js
@@ -21,6 +21,7 @@ export default {
         }),
         lineWidth: 20,
         lineHeight: 3,
+        lineBgSize: 'cover',
         itemStyle: () => ({
             height: '44px'
         }),


### PR DESCRIPTION
业务需求中，u-tabs 中滑块会有需要设置成例如“弧形”这样的形状图，这个目前无法通过API去设置背景图，当前可以通过设置lineColor为透明，再借助css设置滑块的背景图达到目的，为了开发方便，遂将 "lineColor" 设置的 "backgroundColor" 调整为 "background", 并 "Props" 增加 “lineBgSize” 属性设置 “backgroundSize”。

![image](https://user-images.githubusercontent.com/29945352/151651424-9118ffc5-d871-44b1-b535-55d1cb6649b3.png)
