### PR TITLE
fix: u-tabs禁止滚动情况下没有平分tabItem样式

### DIFF
--- a/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
+++ b/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
@@ -21,7 +21,7 @@
 							:key="index"
 							@tap="clickHandler(item, index)"
 							:ref="`u-tabs__wrapper__nav__item-${index}`"
-							:style="[$u.addStyle(itemStyle), {flex: scrollable ? 'initial' : 'auto'}]"
+							:style="[$u.addStyle(itemStyle), {flex: scrollable ? '' : 1}]"
 							:class="[`u-tabs__wrapper__nav__item-${index}`, item.disabled && 'u-tabs__wrapper__nav__item--disabled']"
 						>
 							<text

--- a/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
+++ b/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
@@ -14,9 +14,6 @@
 					<view
 						class="u-tabs__wrapper__nav"
 						ref="u-tabs__wrapper__nav"
-						:style="[{
-							flex: scrollable ? 0 : 1
-						}]"
 					>
 						<view
 							class="u-tabs__wrapper__nav__item"
@@ -24,7 +21,7 @@
 							:key="index"
 							@tap="clickHandler(item, index)"
 							:ref="`u-tabs__wrapper__nav__item-${index}`"
-							:style="[$u.addStyle(itemStyle)]"
+							:style="[$u.addStyle(itemStyle), {flex: scrollable ? 'initial' : 'auto'}]"
 							:class="[`u-tabs__wrapper__nav__item-${index}`, item.disabled && 'u-tabs__wrapper__nav__item--disabled']"
 						>
 							<text


### PR DESCRIPTION
修复scrollable设置为false后没有改变tab-item为flex:1平分样式