### PR TITLE
对picker的change事件延迟回调的回退方案

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,7 @@
     },
     "quickapp" : {},
     "mp-weixin" : {
-        "appid" : "wxc256e348c4032ebd",
+        "appid" : "",
         "setting" : {
             "urlCheck" : false,
             "es6" : false,

--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,7 @@
     },
     "quickapp" : {},
     "mp-weixin" : {
-        "appid" : "",
+		"appid" : "wxc256e348c4032ebd",
         "setting" : {
             "urlCheck" : false,
             "es6" : false,

--- a/pages/componentsC/picker/picker.nvue
+++ b/pages/componentsC/picker/picker.nvue
@@ -174,7 +174,7 @@
 				uni.navigateBack()
 			},
 			change(e) {
-				// console.log('change', e);
+				// console.log(e);
 			},
 			showPicker(index) {
 				this.index = index + 1
@@ -185,7 +185,7 @@
 				this[`show${this.index}`] = false
 			},
 			confirm(e) {
-				// console.log('confirm', e);
+				console.log('confirm', e)
 				this[`show${this.index}`] = false
 			},
 			cancel() {

--- a/pages/componentsC/picker/picker.nvue
+++ b/pages/componentsC/picker/picker.nvue
@@ -29,6 +29,7 @@
 			@change="change"
 			@cancel="cancel"
 			@confirm="confirm"
+			:immediateChange="true"
 		></u-picker>
 		<u-picker
 			:show="show2"
@@ -45,6 +46,7 @@
 			@cancel="cancel"
 			@confirm="confirm"
 			@change="changeHandler1"
+			:immediateChange="true"
 		></u-picker>
 		<u-picker
 			:show="show4"

--- a/uni_modules/uview-ui/components/u-picker/u-picker.vue
+++ b/uni_modules/uview-ui/components/u-picker/u-picker.vue
@@ -28,6 +28,7 @@
 					v-for="(item, index) in innerColumns"
 					:key="index"
 					class="u-picker__view__column"
+					
 				>
 					<text
 						v-if="$u.test.array(item)"
@@ -39,6 +40,8 @@
 							lineHeight: $u.addUnit(itemHeight),
 							fontWeight: index1 === innerIndex[index] ? 'bold' : 'normal'
 						}"
+						@touchstart="columnTouchStart"
+						@touchend="columnTouchEnd"
 					>{{ getItemText(item1) }}</text>
 				</picker-view-column>
 			</picker-view>
@@ -48,6 +51,7 @@
 			>
 				<u-loading-icon mode="circle"></u-loading-icon>
 			</view>
+			<view class="u-picker-overlay" v-if="overlay"></view>
 		</view>
 	</u-popup>
 </template>
@@ -91,6 +95,10 @@ export default {
 			innerColumns: [],
 			// 上一次的变化列索引
 			columnIndex: 0,
+			columnTouchStartY: 0,
+			columnTouchEndY: 0,
+			overlay: false,
+			isConfirm: true
 		}
 	},
 	watch: {
@@ -130,6 +138,7 @@ export default {
 		},
 		// 点击工具栏的确定按钮
 		confirm() {
+			if(!this.isConfirm) return;
 			this.$emit('confirm', {
 				indexs: this.innerIndex,
 				value: this.innerColumns.map((item, index) => item[this.innerIndex[index]]),
@@ -138,6 +147,15 @@ export default {
 		},
 		// 选择器某一列的数据发生变化时触发
 		changeHandler(e) {
+			// 关闭遮罩
+			console.timeEnd('overlay');
+			this.overlay = false;
+			clearTimeout(this.offOverlayTime);
+			this.isConfirm = false;
+			setTimeout(()=>{
+				this.isConfirm = true;
+			},300);
+			
 			const {
 				value
 			} = e.detail
@@ -229,6 +247,27 @@ export default {
 				await uni.$u.sleep()
 			})()
 			return this.innerColumns.map((item, index) => item[this.innerIndex[index]])
+		},
+		// 列项目触摸开始
+		columnTouchStart(e){
+			console.time('overlay');
+			// 这是为了抹平ios的平台差异，screenY为clientY的回退方案
+			this.columnTouchStartY = e.changedTouches[0].clientY || e.changedTouches[0].screenY || 0; 
+		},
+		// 列项目触摸结束
+		columnTouchEnd(e){
+			// console.log(e.changedTouches[0].clientY);
+			// 这是为了抹平ios的平台差异，screenY为clientY的回退方案
+			this.columnTouchEndY = e.changedTouches[0].clientY || e.changedTouches[0].screenY || 0;
+			
+			let diffValue = this.columnTouchEndY - this.columnTouchStartY;
+			// 差值 正负 大于 20 则显示遮罩
+			if(diffValue > 20 || diffValue < -20){
+				this.overlay = true;
+				this.offOverlayTime = setTimeout(()=>{
+					this.overlay = false;
+				},1500);
+			}
 		}
 	},
 }
@@ -279,6 +318,19 @@ export default {
 			align-items: center;
 			background-color: rgba(255, 255, 255, 0.87);
 			z-index: 1000;
+		}
+		
+		&-overlay{
+			position: absolute;
+			background-color: rgba(255,0,0,0.25);
+			top: 0;
+			left: 0;
+			width: 100%;
+			/* #ifdef APP-NVUE */
+			width: 750rpx;
+			/* #endif */
+			height: 300px;
+			z-index: 10;
 		}
 	}
 </style>

--- a/uni_modules/uview-ui/components/u-picker/u-picker.vue
+++ b/uni_modules/uview-ui/components/u-picker/u-picker.vue
@@ -322,7 +322,7 @@ export default {
 		
 		&-overlay{
 			position: absolute;
-			background-color: rgba(255,0,0,0.25);
+			background: transparent; // 遮罩层的颜色为透明
 			top: 0;
 			left: 0;
 			width: 100%;

--- a/uni_modules/uview-ui/libs/config/props/picker.js
+++ b/uni_modules/uview-ui/libs/config/props/picker.js
@@ -25,6 +25,6 @@ export default {
         keyName: 'text',
         closeOnClickOverlay: false,
         defaultIndex: () => [],
-		immediateChange: false
+		immediateChange: true
     }
 }


### PR DESCRIPTION
# picker的change事件伴随着滚动动画结束的时候触发

此问题已经持续了两年，在微信小程序上可以通过immediteChange属性让change事件伴随手指松开触发，但是在其他平台依然未得到有效解决方案。

# 直到触发change事件为止否则不允许点击确定

这也是此方案的思路，在手指开始滚动的时候picker上面增加透明遮罩层，在change事件的时候删除遮罩层，期间什么都点不了，通过这种方式将确认事件强制延迟到change触发之后。

# 其余修复的问题

1. 在ios上touch事件不存在clientX, Y坐标，应用screenX, Y代替。
2. 如果小程序上不加immediateChange属性，则change的回调非常的慢，即便动画明显结束也不立即回调，因此将此属性的默认值更改为true。

# 引起的副作用

1. 可能会使用户感到略微明显的卡顿
2. 遮罩层小概率性的不生效（此问题难以复现，约为15分之1的概率）

# 其他

