### PR TITLE
fix：修复priceFormat在部分情况下出现精度损失问题

### DIFF
--- a/uni_modules/uview-ui/libs/function/index.js
+++ b/uni_modules/uview-ui/libs/function/index.js
@@ -507,8 +507,11 @@ function priceFormat(number, decimals = 0, decimalPoint = '.', thousandsSeparato
 	const dec = (typeof decimalPoint === 'undefined') ? '.' : decimalPoint
 	let s = ''
 	const toFixedFix = function(n, prec) {
-		const k = 10 ** prec
-		return `${Math.ceil(parseInt(n * k)) / k}`
+		const k = 10 ** (prec) 
+		// 这里写成 乘10 再除10 是因为在部分情况下浮点数运算会有精度损失问题
+		// 例如 1.15 * 100 的结果为 114.999... , parseInt后就变成了114, 显然与预期不符
+		// 注意这里 (k * 10)的小括号是必须的，用来保证强制的优先级！
+		return `${Math.ceil(parseInt(n * (k * 10))) / (k * 10)}`
 	}
 
 	s = (prec ? toFixedFix(n, prec) : `${Math.round(n)}`).split('.')


### PR DESCRIPTION
# 引发的问题

1.15 * 100 = 114.99999...，同样出现问题的还有1.12，1.13, 1.14等等

# 解决方案

正如0.1 + 0.2 = 0.30000000000000004，但(1+2)/10 = 0.3一样，可以使用同样的思路适当的把数量级跳高来规避精度问题

即 1. 15 * 1000 / 10 = 115 

close #348 