### PR TITLE
fix: 在unit为rpx后搜索组件内置的搜索图标尺寸不正常

### DIFF
--- a/uni_modules/uview-ui/components/u-search/props.js
+++ b/uni_modules/uview-ui/components/u-search/props.js
@@ -80,6 +80,10 @@ export default {
             type: String,
             default: uni.$u.props.search.searchIcon
         },
+        searchIconSize: {
+            type: [Number, String],
+            default: uni.$u.props.search.searchIconSize
+        },
         // 组件与其他上下左右元素之间的距离，带单位的字符串形式，如"30px"、"30px 20px"等写法
         margin: {
             type: String,

--- a/uni_modules/uview-ui/components/u-search/u-search.vue
+++ b/uni_modules/uview-ui/components/u-search/u-search.vue
@@ -91,6 +91,7 @@
 	 * @property {Boolean}			disabled			是否启用输入框（默认 false ）
 	 * @property {String}			borderColor			边框颜色，配置了颜色，才会有边框 (默认 'transparent' )
 	 * @property {String}			searchIconColor		搜索图标的颜色，默认同输入框字体颜色 (默认 '#909399' )
+	 * @property {Number | String}	searchIconSize 搜索图标的字体，默认26
 	 * @property {String}			color				输入框字体颜色（默认 '#606266' ）
 	 * @property {String}			placeholderColor	placeholder的颜色（默认 '#909399' ）
 	 * @property {String}			searchIcon			输入框左边的图标，可以为uView图标名称或图片路径  (默认 'search' )

--- a/uni_modules/uview-ui/components/u-search/u-search.vue
+++ b/uni_modules/uview-ui/components/u-search/u-search.vue
@@ -22,7 +22,7 @@
 			<view class="u-search__content__icon">
 				<u-icon
 					@tap="clickIcon"
-				    :size="22"
+				    :size="searchIconSize"
 				    :name="searchIcon"
 				    :color="searchIconColor ? searchIconColor : color"
 				></u-icon>

--- a/uni_modules/uview-ui/libs/config/props/search.js
+++ b/uni_modules/uview-ui/libs/config/props/search.js
@@ -23,6 +23,7 @@ export default {
         disabled: false,
         borderColor: 'transparent',
         searchIconColor: '#909399',
+        searchIconSize: 26,
         color: '#606266',
         placeholderColor: '#909399',
         searchIcon: 'search',

--- a/uni_modules/uview-ui/libs/config/props/search.js
+++ b/uni_modules/uview-ui/libs/config/props/search.js
@@ -23,7 +23,7 @@ export default {
         disabled: false,
         borderColor: 'transparent',
         searchIconColor: '#909399',
-        searchIconSize: 26,
+        searchIconSize: 22,
         color: '#606266',
         placeholderColor: '#909399',
         searchIcon: 'search',


### PR DESCRIPTION
在配置uni.$u.config.unit="rpx"后搜索组件的icon尺寸变得过小，其原因是写死的数值22