### PR TITLE
fix：修复`config.unit`属性设为`rpx`时，导航栏占用高度不足导致塌陷的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-navbar/u-navbar.vue
+++ b/uni_modules/uview-ui/components/u-navbar/u-navbar.vue
@@ -4,7 +4,7 @@
 			class="u-navbar__placeholder"
 			v-if="fixed && placeholder"
 			:style="{
-				height: $u.addUnit($u.getPx(height) + $u.sys().statusBarHeight),
+				height: $u.addUnit($u.getPx(height) + $u.sys().statusBarHeight,'px'),
 			}"
 		></view>
 		<view :class="[fixed && 'u-navbar--fixed']">


### PR DESCRIPTION
修复`config.unit`属性设为`rpx`时，导航栏占用高度不足导致塌陷的问题