### PR TITLE
fix: 修复已设置单位 uni..config.unit = 'rpx'时，线型指示器 transform 的位置翻倍，导致指示器超出宽度

### DIFF
--- a/uni_modules/uview-ui/components/u-swiper-indicator/u-swiper-indicator.vue
+++ b/uni_modules/uview-ui/components/u-swiper-indicator/u-swiper-indicator.vue
@@ -57,7 +57,7 @@
 			lineStyle() {
 				let style = {}
 				style.width = uni.$u.addUnit(this.lineWidth)
-				style.transform = `translateX(${ this.current * this.lineWidth }px)`
+				style.transform = `translateX(${ uni.$u.addUnit(this.current * this.lineWidth) })`
 				style.backgroundColor = this.indicatorActiveColor
 				return style
 			},


### PR DESCRIPTION
fix 修复已设置单位 uni.$u.config.unit = 'rpx'时，线型指示器 transform 的位置翻倍，导致指示器超出宽度问题