### PR TITLE
fix: 修复u-switch的transform单位被uni.$u.config.unit设置单位影响

### DIFF
--- a/uni_modules/uview-ui/components/u-switch/u-switch.vue
+++ b/uni_modules/uview-ui/components/u-switch/u-switch.vue
@@ -86,7 +86,7 @@
 				// 如果自定义非激活颜色，将node圆点的尺寸减少两个像素，让其与外边框距离更大一点
 				style.width = uni.$u.addUnit(this.size - this.space)
 				style.height = uni.$u.addUnit(this.size - this.space)
-				style.transform = `translateX(${this.value === this.activeValue ? -this.space : -this.size}px)`
+				style.transform = `translateX(${this.value === this.activeValue ? -this.space : -this.size}${uni.$u.config.unit})`
 				return style
 			},
 			bgStyle() {


### PR DESCRIPTION
使用uni.$u.config.unit 设置了全局单位后，u-switch组件在false状态会出现样式异常。修改px为配置全局单位