### PR TITLE
按钮可以自定义字体大小

### DIFF
--- a/pages/componentsA/button/button.nvue
+++ b/pages/componentsA/button/button.nvue
@@ -290,6 +290,25 @@
 				</view>
 			</view>
 		</view>
+		
+		<view class="u-demo-block">
+			<text class="u-demo-block__title">自定义按钮文字大小</text>
+			<view class="u-demo-block__content">
+				<view class="u-page__button-item">
+					<u-button
+					    text="默认大小(14px)"
+					    type="success"
+					></u-button>
+				</view>
+				<view class="u-page__button-item">
+					<u-button
+					    text="自定义大小(16px)"
+					    type="success"
+						:fontSize="16"
+					></u-button>
+				</view>
+			</view>
+		</view>
 	</view>
 </template>
 

--- a/uni_modules/uview-ui/components/u-button/props.js
+++ b/uni_modules/uview-ui/components/u-button/props.js
@@ -156,6 +156,11 @@ export default {
         color: {
             type: String,
             default: uni.$u.props.button.color
-        }
+        },
+		// 自定义按钮字体大小
+		fontSize: {
+		  type: Number,
+		  default: uni.$u.props.button.fontSize
+		}
     }
 }

--- a/uni_modules/uview-ui/components/u-button/u-button.vue
+++ b/uni_modules/uview-ui/components/u-button/u-button.vue
@@ -251,13 +251,13 @@ export default {
         },
         // 字体大小
         textSize() {
-            let fontSize = 14,
-                { size } = this;
-            if (size === "large") fontSize = 16;
-            if (size === "normal") fontSize = 14;
-            if (size === "small") fontSize = 12;
-            if (size === "mini") fontSize = 10;
-            return fontSize;
+            let { size } = this;
+            if (this.fontSize !== uni.$u.props.button.fontSize) return this.fontSize;
+            if (size === "large") return 16;
+            if (size === "normal") return 14;
+            if (size === "small") return 12;
+            if (size === "mini") return 10;
+            return 14;
         },
     },
     methods: {

--- a/uni_modules/uview-ui/libs/config/props/button.js
+++ b/uni_modules/uview-ui/libs/config/props/button.js
@@ -37,6 +37,7 @@ export default {
         text: '',
         icon: '',
         iconColor: '',
-        color: ''
+        color: '',
+		fontSize: 14
     }
 }


### PR DESCRIPTION
在实际使用过程中发现按钮字体大小是写死的14px，故新增按钮可以自定义大小功能，button添加了一个fontSize的props字段，用来自定义字体大小，优先级最高