### PR TITLE
fix: 修复时间选择器索引不正确问题

### DIFF
--- a/uni_modules/uview-ui/components/u-datetime-picker/u-datetime-picker.vue
+++ b/uni_modules/uview-ui/components/u-datetime-picker/u-datetime-picker.vue
@@ -148,7 +148,7 @@
 					let date = parseInt(values[2] ? this.intercept(values[2][indexs[2]]) : 1)
 					let hour = 0, minute = 0
 					// 此月份的最大天数
-					const maxDate = dayjs(`${year}-${month}-${date}`).daysInMonth()
+					const maxDate = dayjs(`${year}-${month}`).daysInMonth()
 					// year-month模式下，date不会出现在列中，设置为1，为了符合后边需要减1的需求
 					if (this.mode === 'year-month') {
 					    date = 1


### PR DESCRIPTION
如果当前选中的日期为3月31日，此时将月份选中成2月时，索引会更新成3月3日