### PR TITLE
fix: u-switch 在单位设置为rpx时，未选中状态下，偏移超出范围

### DIFF
--- a/uni_modules/uview-ui/components/u-switch/u-switch.vue
+++ b/uni_modules/uview-ui/components/u-switch/u-switch.vue
@@ -86,7 +86,7 @@
 				// 如果自定义非激活颜色，将node圆点的尺寸减少两个像素，让其与外边框距离更大一点
 				style.width = uni.$u.addUnit(this.size - this.space)
 				style.height = uni.$u.addUnit(this.size - this.space)
-				style.transform = `translateX(${this.value === this.activeValue ? -this.space : -this.size}px)`
+				style.transform = `translateX(${this.value === this.activeValue ? uni.$u.addUnit(-this.space) : uni.$u.addUnit(-this.size)})`
 				return style
 			},
 			bgStyle() {


### PR DESCRIPTION
fix: u-switch 在单位设置为rpx时，未选中状态下，偏移超出范围