### PR TITLE
fix(u-upload): 修复微信小程序和vue环境下成功图标三角形不显示，判断是否promise对象错误

### DIFF
--- a/uni_modules/uview-ui/components/u-upload/u-upload.vue
+++ b/uni_modules/uview-ui/components/u-upload/u-upload.vue
@@ -486,6 +486,7 @@
 			border-bottom-color: $u-upload-success-border-bottom-color;
 			border-right-color: $u-upload-success-border-right-color;
 			border-width: $u-upload-success-border-width;
+			border-style: solid;
 			align-items: center;
 			justify-content: center;
 			/* #endif */

--- a/uni_modules/uview-ui/libs/function/test.js
+++ b/uni_modules/uview-ui/libs/function/test.js
@@ -225,7 +225,7 @@ function func(value) {
  * @param {Object} value
  */
 function promise(value) {
-    return object(value) && func(value.then) && func(value.catch)
+    return Object.prototype.toString.call(value) === '[object Promise]' && func(value.then) && func(value.catch)
 }
 
 /** 是否图片格式


### PR DESCRIPTION
1.修复微信小程序-vue中upload组件成功图标缺少border-style样式，导致不显示。
2.修复upload组件中的onBeforeRead方法中判断是否promise对象错误，[object Object]  !==  [object Promise]