### PR TITLE
fix: 修复 Image 的属性 width 和 height 设置百分比无效的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-image/u-image.vue
+++ b/uni_modules/uview-ui/components/u-image/u-image.vue
@@ -3,6 +3,7 @@
 		mode="fade"
 		:show="show"
 		:duration="fade ? 1000 : 0"
+		:customStyle="`width: ${wrapStyle.width}; height: ${wrapStyle.height}`"
 	>
 		<view
 			class="u-image"


### PR DESCRIPTION
设置 Image 属性 width 和 height 为 100% 无效，经查为 u-image 组件内部的 u-transition 未接收传入的宽高，导致子元素宽高塌陷，将 width 和 height 传入 u-transition 的 customStyle 属性解决：

:customStyle="`width: ${wrapStyle.width}; height: ${wrapStyle.height}`"