### PR TITLE
fix: 修复 Image 的属性 width 和 height 设置百分比无效的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-image/u-image.vue
+++ b/uni_modules/uview-ui/components/u-image/u-image.vue
@@ -3,6 +3,7 @@
 		mode="fade"
 		:show="show"
 		:duration="fade ? 1000 : 0"
+		:customStyle="`width: ${$u.addUnit(width)}; height: ${$u.addUnit(height)}`"
 	>
 		<view
 			class="u-image"
@@ -20,8 +21,8 @@
 				class="u-image__image"
 				:style="{
 					borderRadius: shape == 'circle' ? '10000px' : $u.addUnit(radius),
-					width: $u.addUnit(width),
-					height: $u.addUnit(height)
+					width: '100%',
+					height: '100%'
 				}"
 			></image>
 			<view
@@ -30,8 +31,8 @@
 				:style="{
 					borderRadius: shape == 'circle' ? '50%' : $u.addUnit(radius),
 					backgroundColor: this.bgColor,
-					width: $u.addUnit(width),
-					height: $u.addUnit(height)
+					width: '100%',
+					height: '100%'
 				}"
 			>
 				<slot name="loading">
@@ -47,15 +48,15 @@
 				class="u-image__error"
 				:style="{
 					borderRadius: shape == 'circle' ? '50%' : $u.addUnit(radius),
-					width: $u.addUnit(width),
-					height: $u.addUnit(height)
+					width: '100%',
+					height: '100%'
 				}"
 			>
 				<slot name="error">
 					<u-icon
 						:name="errorIcon"
-						:width="width"
-						:height="height"
+						width="100%"
+						height="100%"
 					></u-icon>
 				</slot>
 			</view>
@@ -129,8 +130,8 @@
 			wrapStyle() {
 				let style = {};
 				// 通过调用addUnit()方法，如果有单位，如百分比，px单位等，直接返回，如果是纯粹的数值，则加上rpx单位
-				style.width = this.$u.addUnit(this.width);
-				style.height = this.$u.addUnit(this.height);
+				style.width = '100%';
+				style.height = '100%';
 				// 如果是显示圆形，设置一个很多的半径值即可
 				style.borderRadius = this.shape == 'circle' ? '10000px' : uni.$u.addUnit(this.radius)
 				// 如果设置圆角，必须要有hidden，否则可能圆角无效


### PR DESCRIPTION
设置 Image 属性 width 和 height 为 100% 无效，经查为 u-image 组件内部的 u-transition 未接收传入的宽高，导致子元素宽高塌陷，将 width 和 height 传入 u-transition 的 customStyle 属性解决：

:customStyle="width: ${wrapStyle.width}; height: ${wrapStyle.height}"