### PR TITLE
修复u--form组件BUG，表单校验trigger触发器参数无效问题

### DIFF
--- a/uni_modules/uview-ui/components/u--form/u--form.vue
+++ b/uni_modules/uview-ui/components/u--form/u--form.vue
@@ -52,11 +52,11 @@
 				// #endif
 				return this.$refs.uForm.validate()
 			},
-			validateField(value, callback) {
+			validateField(value, callback, event) {
 				// #ifdef MP-WEIXIN
 				this.setMpData()
 				// #endif
-				return this.$refs.uForm.validateField(value, callback)
+				return this.$refs.uForm.validateField(value, callback, event)
 			},
 			resetFields() {
 				// #ifdef MP-WEIXIN


### PR DESCRIPTION
解决在表单校验中，trigger参数写‘blur’时，输入文字会触发校验的bug