### PR TITLE
Update u-loading-icon.vue

### DIFF
--- a/uni_modules/uview-ui/components/u-loading-icon/u-loading-icon.vue
+++ b/uni_modules/uview-ui/components/u-loading-icon/u-loading-icon.vue
@@ -25,7 +25,7 @@
 			<block v-if="mode === 'spinner'">
 				<!-- #ifndef APP-NVUE -->
 				<view
-					v-for="(item, index) in array12"
+					v-for="index in array12"
 					:key="index"
 					class="u-loading-icon__dot"
 				>


### PR DESCRIPTION
因为item为undefined，在支付宝小程序中会导致程序崩溃