### PR TITLE
fix：修改loadmore组件中的加载图标由之前的固定大小 17 改为添加 iconSize 属性来自定义图标大小以满足更多需求

### DIFF
--- a/pages/componentsC/loadmore/loadmore.nvue
+++ b/pages/componentsC/loadmore/loadmore.nvue
@@ -6,6 +6,7 @@
 				<u-loadmore
 					status="loading"
 					:isDot="true"
+					:iconSize="17"
 				></u-loadmore>
 			</view>
 		</view>

--- a/uni_modules/uview-ui/components/u-loadmore/props.js
+++ b/uni_modules/uview-ui/components/u-loadmore/props.js
@@ -20,6 +20,11 @@ export default {
             type: [String, Number],
             default: uni.$u.props.loadmore.fontSize
         },
+		// 图标大小
+		iconSize: {
+		    type: [String, Number],
+		    default: uni.$u.props.loadmore.iconSize
+		},
         // 字体颜色
         color: {
             type: String,

--- a/uni_modules/uview-ui/components/u-loadmore/u-loadmore.vue
+++ b/uni_modules/uview-ui/components/u-loadmore/u-loadmore.vue
@@ -28,7 +28,7 @@
 			>
 				<u-loading-icon
 				    :color="iconColor"
-				    size="17"
+				    :size="iconSize"
 				    :mode="loadingIcon"
 				></u-loading-icon>
 			</view>
@@ -60,6 +60,7 @@
 	 * @property {String}			bgColor			组件背景颜色，在页面是非白色时会用到（默认 'transparent' ）
 	 * @property {Boolean}			icon			加载中时是否显示图标（默认 true ）
 	 * @property {String | Number}	fontSize		字体大小（默认 14 ）
+	 * @property {String | Number}	iconSize		图标大小（默认 17 ）
 	 * @property {String}			color			字体颜色（默认 '#606266' ）
 	 * @property {String}			loadingIcon		加载图标（默认 'circle' ）
 	 * @property {String}			loadmoreText	加载前的提示语（默认 '加载更多' ）

--- a/uni_modules/uview-ui/libs/config/props/loadmore.js
+++ b/uni_modules/uview-ui/libs/config/props/loadmore.js
@@ -14,6 +14,7 @@ export default {
         bgColor: 'transparent',
         icon: true,
         fontSize: 14,
+		iconSize: 17,
         color: '#606266',
         loadingIcon: 'spinner',
         loadmoreText: '加载更多',


### PR DESCRIPTION
修改代码文件：uni_modules/uview-ui/components/u-loadmore
修改内容：修改loadmore组件中的加载图标由之前的固定大小 17 改为添加 iconSize 属性来自定义图标大小以满足更多需求。

修改示例文件：pages/componentsC/loadmore
修改示例内容：修改基本使用案例添加 iconSize 进行测试。

修改结果：测试有效