### PR TITLE
fix:删除无用参数singleIndex

### DIFF
--- a/uni_modules/uview-ui/components/u-picker/props.js
+++ b/uni_modules/uview-ui/components/u-picker/props.js
@@ -50,11 +50,6 @@ export default {
             type: String,
             default: uni.$u.props.picker.confirmColor
         },
-        // 选择器只有一列时，默认选中项的索引，从0开始
-        singleIndex: {
-            type: [String, Number],
-            default: uni.$u.props.picker.singleIndex
-        },
         // 每列中可见选项的数量
         visibleItemCount: {
             type: [String, Number],

--- a/uni_modules/uview-ui/components/u-picker/u-picker.vue
+++ b/uni_modules/uview-ui/components/u-picker/u-picker.vue
@@ -66,7 +66,6 @@
  * @property {String}			confirmText			确认按钮的文字（默认 '确定' ）
  * @property {String}			cancelColor			取消按钮的颜色（默认 '#909193' ）
  * @property {String}			confirmColor		确认按钮的颜色（默认 '#3c9cff' ）
- * @property {Array}			singleIndex			选择器只有一列时，默认选中项的索引，从0开始（默认 0 ）
  * @property {String | Number}	visibleItemCount	每列中可见选项的数量（默认 5 ）
  * @property {String}			keyName				选项对象中，需要展示的属性键名（默认 'text' ）
  * @property {Boolean}			closeOnClickOverlay	是否允许点击遮罩关闭选择器（默认 false ）

--- a/uni_modules/uview-ui/libs/config/props/picker.js
+++ b/uni_modules/uview-ui/libs/config/props/picker.js
@@ -20,7 +20,6 @@ export default {
         confirmText: '确定',
         cancelColor: '#909193',
         confirmColor: '#3c9cff',
-        singleIndex: 0,
         visibleItemCount: 5,
         keyName: 'text',
         closeOnClickOverlay: false,


### PR DESCRIPTION
singleIndex在源码中没有任何引用，且已经提供defaultIndex作为各列的默认索引，单列选择器同样可以使用，所以singleIndex参数无实际用途。已在文档提交pr13删除对应部分。