### PR TITLE
feat(u-link): 添加 target 属性(仅在 H5 端生效)

### DIFF
--- a/uni_modules/uview-ui/components/u-link/props.js
+++ b/uni_modules/uview-ui/components/u-link/props.js
@@ -34,6 +34,14 @@ export default {
         text: {
             type: String,
             default: uni.$u.props.link.text
+        },
+        // 该属性指定在何处显示链接的资源（仅在 H5 端可用，默认值：_blank）
+        target: {
+            type: String,
+            default: uni.$u.props.link.target,
+			validator: function(value) {
+				return ['_blank', '_self', '_parent', '_top'].indexOf(value) !== -1
+			}
         }
     }
 }

--- a/uni_modules/uview-ui/components/u-link/u-link.vue
+++ b/uni_modules/uview-ui/components/u-link/u-link.vue
@@ -20,6 +20,7 @@
 	 * @property {String}			mpTips		各个小程序平台把链接复制到粘贴板后的提示语（默认“链接已复制，请在浏览器打开”）
 	 * @property {String}			lineColor	下划线颜色，默认同color参数颜色 
 	 * @property {String}			text		超链接的问题，不使用slot形式传入，是因为nvue下无法修改颜色 
+	 * @property {String}			target		该属性指定在何处显示链接的资源（仅在 H5 端可用，默认值：_blank，可选值: _blank, _self, _parent, _top）
 	 * @property {Object}			customStyle	定义需要用到的外部样式
 	 * 
 	 * @example <u-link href="http://www.uviewui.com">蜀道难，难于上青天</u-link>
@@ -49,7 +50,7 @@
 				plus.runtime.openURL(this.href)
 				// #endif
 				// #ifdef H5
-				window.open(this.href)
+				window.open(this.href, this.target)
 				// #endif
 				// #ifdef MP
 				uni.setClipboardData({
@@ -69,15 +70,12 @@
 </script>
 
 <style lang="scss" scoped>
-	@import "../../libs/css/components.scss";
-	$u-link-line-height:1 !default;
+	$u-link-line-height: 1 !default;
 
 	.u-link {
 		/* #ifndef APP-NVUE */
 		line-height: $u-link-line-height;
 		/* #endif */
-		@include flex;
-		flex-wrap: wrap;
-		flex: 1;
+		width: max-content;
 	}
 </style>

--- a/uni_modules/uview-ui/libs/config/props/link.js
+++ b/uni_modules/uview-ui/libs/config/props/link.js
@@ -21,6 +21,7 @@ export default {
         href: '',
         mpTips: '链接已复制，请在浏览器打开',
         lineColor: '',
-        text: ''
+        text: '',
+		target: '_blank'
     }
 }


### PR DESCRIPTION
添加 target 属性(仅在 H5 端生效)，用于控制连接打开的方式，与 H5 端的 a 标签的 target 行为保持一致