### PR TITLE
fix(u-swiper): 修改视频暂停方法的判断

### DIFF
--- a/uni_modules/uview-ui/components/u-swiper/u-swiper.vue
+++ b/uni_modules/uview-ui/components/u-swiper/u-swiper.vue
@@ -183,7 +183,8 @@
 			// 切换轮播时，暂停视频播放
 			pauseVideo(index) {
 				const lastItem = this.getSource(this.list[index])
-				if (uni.$u.test.video(lastItem)) {
+				const isVideo = uni.$u.test.video(lastItem) || this.getItemType(this.list[index]) === 'video'
+				if (isVideo) {
 					// 当视频隐藏时，暂停播放
 					const video = uni.createVideoContext(`video-${index}`, this)
 					video.pause()


### PR DESCRIPTION
使用 `uni.$u.test.video(lastItem)` 来判断是否为视频的健壮性不够，链接不一定存在后缀，修改成通过 type 和 url 共同判断提高可用性