### PR TITLE
fix(u-loadmore):修复props之lineColor属性type定义

### DIFF
--- a/uni_modules/uview-ui/components/u-loadmore/props.js
+++ b/uni_modules/uview-ui/components/u-loadmore/props.js
@@ -83,7 +83,7 @@ export default {
         },
 		// 线条颜色
 		lineColor: {
-		    type: Boolean,
+		    type: String,
 		    default: uni.$u.props.loadmore.lineColor
 		},
 		// 是否虚线，true-虚线，false-实线


### PR DESCRIPTION
https://github.com/umicro/uView2.0/blob/a4dc03d24ac61f4f070efab09675a21980bf2593/uni_modules/uview-ui/components/u-loadmore/props.js#L84-L88