### PR TITLE
fix(u-list): 列表默认高度改为屏幕高度除u-list上方元素的剩余可用高度

### DIFF
--- a/uni_modules/uview-ui/components/u-list/u-list.vue
+++ b/uni_modules/uview-ui/components/u-list/u-list.vue
@@ -79,7 +79,7 @@
 				// vue下，scroll-view在上拉加载时的偏移值
 				offset: 0,
 				sys: uni.$u.sys(),
-				// 记录u-list距离屏幕顶部的高度
+				// 记录u-list距离屏幕可用高度顶部的偏移值
 				topOfScreen: 0
 			}
 		},
@@ -89,8 +89,7 @@
 					addUnit = uni.$u.addUnit
 				if (this.width != 0) style.width = addUnit(this.width)
 				if (this.height != 0) style.height = addUnit(this.height)
-				// - 如果没有定义列表高度，则默认使用屏幕高度
-				// + 如果没有定义列表高度，则默认使用屏幕高度 减去 剩余可用高度
+				// 如果没有定义列表高度，则默认使用屏幕高度减去u-list上方元素高度
 				if (!style.height) style.height = addUnit(this.sys.windowHeight - this.topOfScreen, 'px')
 					return uni.$u.deepMerge(style, uni.$u.addStyle(this.customStyle))
 			}
@@ -106,21 +105,21 @@
 			this.anchors = []
 		},
 		mounted() {
-			// #ifdef APP-NVUE
-			console.log('我是nvue')
-			dom.getComponentRect(this.$refs.uList, option => {  
-				this.topOfScreen = option.size.top
-			})
-			// #endif
-
-			// #ifndef APP-NVUE
-			console.log('我不是nvue')
-			this.$u.getRect('.u-list').then(res => {
-				this.topOfScreen = res.top
-			})
-			// #endif
+			this.setTopOfScreen()
 		},
 		methods: {
+			setTopOfScreen() {
+				// #ifdef APP-NVUE
+				dom.getComponentRect(this.$refs.uList, option => {  
+					this.topOfScreen = option.size.top
+				})
+				// #endif
+				// #ifndef APP-NVUE
+				this.$u.getRect('.u-list').then(res => {
+					this.topOfScreen = res.top
+				})
+				// #endif
+			},
 			updateOffsetFromChild(top) {
 				this.offset = top
 			},

--- a/uni_modules/uview-ui/components/u-list/u-list.vue
+++ b/uni_modules/uview-ui/components/u-list/u-list.vue
@@ -2,6 +2,7 @@
 	<!-- #ifdef APP-NVUE -->
 	<list
 		class="u-list"
+		ref="uList"
 		:enableBackToTop="enableBackToTop"
 		:loadmoreoffset="lowerThreshold"
 		:showScrollbar="showScrollbar"
@@ -77,7 +78,9 @@
 				innerScrollTop: 0,
 				// vue下，scroll-view在上拉加载时的偏移值
 				offset: 0,
-				sys: uni.$u.sys()
+				sys: uni.$u.sys(),
+				// 记录u-list距离屏幕顶部的高度
+				topOfScreen: 0
 			}
 		},
 		computed: {
@@ -86,9 +89,10 @@
 					addUnit = uni.$u.addUnit
 				if (this.width != 0) style.width = addUnit(this.width)
 				if (this.height != 0) style.height = addUnit(this.height)
-				// 如果没有定义列表高度，则默认使用屏幕高度
-				if (!style.height) style.height = addUnit(this.sys.windowHeight, 'px')
-				return uni.$u.deepMerge(style, uni.$u.addStyle(this.customStyle))
+				// - 如果没有定义列表高度，则默认使用屏幕高度
+				// + 如果没有定义列表高度，则默认使用屏幕高度 减去 剩余可用高度
+				if (!style.height) style.height = addUnit(this.sys.windowHeight - this.topOfScreen, 'px')
+					return uni.$u.deepMerge(style, uni.$u.addStyle(this.customStyle))
 			}
 		},
 		provide() {
@@ -101,7 +105,21 @@
 			this.children = []
 			this.anchors = []
 		},
-		mounted() {},
+		mounted() {
+			// #ifdef APP-NVUE
+			console.log('我是nvue')
+			dom.getComponentRect(this.$refs.uList, option => {  
+				this.topOfScreen = option.size.top
+			})
+			// #endif
+
+			// #ifndef APP-NVUE
+			console.log('我不是nvue')
+			this.$u.getRect('.u-list').then(res => {
+				this.topOfScreen = res.top
+			})
+			// #endif
+		},
 		methods: {
 			updateOffsetFromChild(top) {
 				this.offset = top


### PR DESCRIPTION
组件存在的问题：当列表不设置height属性时，其默认高度为屏幕可用高度（我这里为800px）。
![image](https://user-images.githubusercontent.com/65105426/178103041-639a40ea-098f-4ae3-ab8f-baea22baba2a.png)
此时一个页面只有List一个组件，可以看到列表项不足以占满全屏，页面无溢出，不会出现滚动条。
然后我在该页面List组件上方增加一个元素（我这里是一个背景色为红色的高度为50px的view）。
![image](https://user-images.githubusercontent.com/65105426/178103140-4095c70d-56dd-4502-806e-9112b687cb34.png)
此时列表项还是不足以占满全屏，合理的布局应该为页面无溢出，不出现滚动条。但是此时由于view的高度50px+列表默认高度800px大于屏幕可用高度800px，导致元素溢出页面，出现滚动条。
![image](https://user-images.githubusercontent.com/65105426/178103214-2ddc16cb-6e37-4ca1-bbb4-b55a25a03614.png)
所以我认为列表的默认高度应该为屏幕可用高度（如800px）减去列表组件上方元素高度（如50px）的剩余高度（750px），经修改代码后，当列表项不足以占满页面剩余高度时，不会出现滚动条，效果如下。
![QQ图片20220709192213](https://user-images.githubusercontent.com/65105426/178103633-f886db89-1859-4934-af71-213a631fa081.png)
经自测，当列表项超出列表高度时，可正常触发scrolltolower事件(一页加载20条数据)，以下为自测截图
**安卓手机(nvue):**
![image](https://user-images.githubusercontent.com/65105426/178103764-14b1e1df-928c-402c-990c-82925dca083c.png)
![2E6F913B08F7C800DF8EECEC5BC22419](https://user-images.githubusercontent.com/65105426/178103782-3814820f-2b8c-4c23-bb40-f1db3734d62b.jpg)
**安卓手机(app-vue):**
![image](https://user-images.githubusercontent.com/65105426/178103868-d509e961-7401-4ecd-9506-3d63267c6dd5.png)
![77EE99141A4F6527C646927B4FC3F954](https://user-images.githubusercontent.com/65105426/178103879-9ff8b558-2d76-41e4-8f77-3c5de4a13449.png)

**H5(vue):**
![image](https://user-images.githubusercontent.com/65105426/178103811-e7e74f39-0c85-4eef-b7df-3af1c529a62d.png)

**微信小程序**
没有测试，因为没有微信开发者工具（不想下载，不过我觉得应该和h5差不多效果吧？）

**可能存在的不足**
1、只考虑列表组件上方元素的高度，没有考虑计算列表下方元素的高度，但是我认为如果列表下方存在元素的话，开发者会优先配置height属性，这样才能保证列表下方的元素处于可视范围。
2、只有在mounted生命周期里才能获取列表组件距屏幕可用高度的top值，因此会比之前多计算了一次。（组件挂载之前计算一次，mounted里经获取top值后计算属性又计算了一次。）