### PR TITLE
fix:解决overlay滚动穿透问题

### DIFF
--- a/uni_modules/uview-ui/components/u-transition/u-transition.vue
+++ b/uni_modules/uview-ui/components/u-transition/u-transition.vue
@@ -6,7 +6,7 @@
 		@tap="clickHandler"
 		:class="classes"
 		:style="[mergeStyle]"
-		@touchmove="noop"
+		@touchmove.stop.prevent="noop"
 	>
 		<slot />
 	</view>


### PR DESCRIPTION
overlay组件使用了transition组件，而transition组件的@touchmove=“noop”没有阻止弹层的滚动穿透问题