### PR TITLE
fix：u-swiper-action-item的name组件可以支持传递对象

### DIFF
--- a/uni_modules/uview-ui/components/u-swipe-action-item/props.js
+++ b/uni_modules/uview-ui/components/u-swipe-action-item/props.js
@@ -7,7 +7,7 @@ export default {
         },
         // 标识符，如果是v-for，可用index索引值
         name: {
-            type: [String, Number],
+            type: [String, Number,Object],
             default: uni.$u.props.swipeActionItem.name
         },
         // 是否禁用


### PR DESCRIPTION
在使用中有些时候需要传递很多数据那么就会出现报错情况，添加了这个就不会出现，解决vue的props校验报错
![image](https://user-images.githubusercontent.com/39890885/194740056-af4289e1-d6e4-42ab-a8bc-6a543a8cb2c7.png)
![image](https://user-images.githubusercontent.com/39890885/194740068-f81f3702-7409-4a2b-9fc7-b9aa596804b0.png)
