### PR TITLE
fix(u-calendar):修复通过setConfig方法设置unit为rpx后,u-calendar的日期和周数星期对不齐问题

### DIFF
--- a/uni_modules/uview-ui/components/u-calendar/month.vue
+++ b/uni_modules/uview-ui/components/u-calendar/month.vue
@@ -158,7 +158,7 @@
 					if (index2 === 0) {
 						// 获取当前为星期几，如果为0，则为星期天，减一为每月第一天时，需要向左偏移的item个数
 						week = (week === 0 ? 7 : week) - 1
-						style.marginLeft = uni.$u.addUnit(week * dayWidth)
+						style.marginLeft = week * dayWidth + 'px';
 					}
 					if (this.mode === 'range') {
 						// 之所以需要这么写，是因为DCloud公司的iOS客户端的开发者能力有限导致的bug


### PR DESCRIPTION
之前提过issue,这块左边的margin计算应该是按px算的，不用再用uni.$u.addUnit设置了，如果全局设置了’rpx‘，会有如下图错误！求大大审核。![image](https://user-images.githubusercontent.com/47049300/196643700-d8234a91-0651-4d6b-9c40-0b928373ade9.png)
