### PR TITLE
关于让折叠面板slot适应微信小程序 内容截图等可参考我写的这篇文章https://juejin.cn/post/715614668005…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,7 @@
     },
     "quickapp" : {},
     "mp-weixin" : {
-        "appid" : "wxc256e348c4032ebd",
+        "appid" : "wxc72701ef86673a90",
         "setting" : {
             "urlCheck" : false,
             "es6" : false,

--- a/pages/componentsB/collapse/collapse.nvue
+++ b/pages/componentsB/collapse/collapse.nvue
@@ -97,7 +97,7 @@
 			</u-collapse>
 		</view>
 		<!-- 微信小程序不支持，因为微信中不支持 <slot name="title" slot="title" />的写法 -->
-		<!-- #ifndef MP-WEIXIN -->
+		
 		<view class="u-page__item">
 			<text class="u-page__item__title">自定义标题和内容</text>
 			<u-collapse
@@ -105,7 +105,7 @@
 			>
 				<u-collapse-item
 				>
-					<text slot="title" class="u-page__item__title__slot-title">文档指南</text>
+					<text slot="title1" class="u-page__item__title__slot-title">文档指南</text>
 					<text class="u-collapse-content">涵盖uniapp各个方面，给开发者方向指导和设计理念，让您茅塞顿开，一马平川</text>
 				</u-collapse-item>
 				<!-- <u-collapse-item
@@ -117,18 +117,18 @@
 				<u-collapse-item
 				    title="组件全面"
 				>
-					<u-icon name="tags-fill" size="20" slot="icon"></u-icon>
+					<u-icon name="tags-fill" size="20" slot="icon1"></u-icon>
 					<text class="u-collapse-content">众多组件覆盖开发过程的各个需求，组件功能丰富，多端兼容。让您快速集成，开箱即用</text>
 				</u-collapse-item>
 				<u-collapse-item
 				    title="众多利器"
 				>
-					<text slot="value" class="u-page__item__title__slot-title">自定义内容</text>
+					<text slot="value1" class="u-page__item__title__slot-title">自定义内容</text>
 					<text class="u-collapse-content">众多的贴心小工具，是您开发过程中召之即来的利器，让您飞镖在手，百步穿杨</text>
 				</u-collapse-item>
 			</u-collapse>
 		</view>
-		<!-- #endif -->
+		
 		<u-gap height="50"></u-gap>
 	</view>
 </template>

--- a/uni_modules/uview-ui/components/u-collapse-item/u-collapse-item.vue
+++ b/uni_modules/uview-ui/components/u-collapse-item/u-collapse-item.vue
@@ -12,21 +12,22 @@
 			:arrowDirection="expanded ? 'up' : 'down'"
 			:disabled="disabled"
 		>
-			<!-- #ifndef MP-WEIXIN -->
-			<!-- 微信小程序不支持，因为微信中不支持 <slot name="title" slot="title" />的写法 -->
 			<template slot="title">
-				<slot name="title"></slot>
+				<slot name="title1">{{title}}</slot>
+				
 			</template>
-			<template slot="icon">
-				<slot name="icon"></slot>
+			<template slot="icon" >
+				<slot name="icon1"></slot>
 			</template>
-			<template slot="value">
-				<slot name="value"></slot>
+			<template slot="value" >
+				<slot name="value1"></slot>
 			</template>
+			
 			<template slot="right-icon">
-				<slot name="right-icon"></slot>
+				<slot name="right-icon1" v-if="$slots['right-icon1']">
+				</slot>
+				<u-icon name="arrow-right"  v-else></u-icon>
 			</template>
-			<!-- #endif -->
 		</u-cell>
 		<view
 			class="u-collapse-item__content"


### PR DESCRIPTION
关于让折叠面板在微信小程序中使用slot
代码内容截图等可参考我写的这篇文章https://juejin.cn/post/7156146680058871816
微信小程序截图效果：
![b99621c579564a01537ce9afd172fdb](https://user-images.githubusercontent.com/69777186/196880343-8069ce3e-7f39-4395-abee-e20629d20baa.png)


