### PR TITLE
fix: DatetimePicker v-model 绑定异步设置无效；

### DIFF
--- a/pages/componentsC/datetimePicker/datetimePicker.nvue
+++ b/pages/componentsC/datetimePicker/datetimePicker.nvue
@@ -97,10 +97,27 @@
 			@change="change"
 			@close="close"
 		></u-datetime-picker>
+		<u-datetime-picker
+			:show="show8"
+			ref="asyncValue8"
+			v-model="value8"
+			mode="datetime"
+			closeOnClickOverlay
+			@confirm="confirm"
+			@cancel="cancel"
+			@change="change"
+			@close="close"
+		></u-datetime-picker>
 	</view>
 </template>
 <script>
 	export default {
+		onShow() {
+			// 模拟异步设置时间 asyncValue8
+			setTimeout(() => {
+				this.asyncValue8 = '2025-12-19 11:28:10'
+			}, 500)
+		},
 		data() {
 			const d = new Date()
 			const year = d.getFullYear()
@@ -115,6 +132,8 @@
 				value5: Number(new Date()),
 				value6: Number(new Date()),
 				value7: Number(new Date()),
+				// value8: Number(new Date()),
+				asyncValue8: null,
 				show1: false,
 				show2: false,
 				show3: false,
@@ -122,6 +141,7 @@
 				show5: false,
 				show6: false,
 				show7: false,
+				show8: false,
 				list: [{
 						title: '完整日期时间',
 						iconUrl: 'https://cdn.uviewui.com/uview/demo/datetime-picker/6.png'
@@ -146,8 +166,24 @@
 					}, {
 						title: '限制最大最小值',
 						iconUrl: 'https://cdn.uviewui.com/uview/demo/datetime-picker/7.png'
+					},{
+						title: '异步设置时间',
+						iconUrl: 'https://cdn.uviewui.com/uview/demo/datetime-picker/6.png'
 					}
 				]
+			}
+		},
+		computed: {
+			value8: {
+				get() {
+					return this.asyncValue8 ? this.asyncValue8 : Number(new Date())
+					// return this.asyncValue8 || Number(new Date())
+				},
+				set(newValue, oldValue) {
+					// this.asyncValue8 = uni.$u.timeFormat(newValue, 'yyyy-mm-dd hh:MM:ss')
+					this.asyncValue8 = newValue
+					this.show8 = false;
+				}
 			}
 		},
 		methods: {

--- a/uni_modules/uview-ui/components/u-datetime-picker/u-datetime-picker.vue
+++ b/uni_modules/uview-ui/components/u-datetime-picker/u-datetime-picker.vue
@@ -87,7 +87,7 @@
 		computed: {
 			// 如果以下这些变量发生了变化，意味着需要重新初始化各列的值
 			propsChange() {
-				return [this.mode, this.maxDate, this.minDate, this.minHour, this.maxHour, this.minMinute, this.maxMinute, this.filter, ]
+				return [this.mode, this.maxDate, this.minDate, this.minHour, this.maxHour, this.minMinute, this.maxMinute, this.filter, this.value, ]
 			}
 		},
 		mounted() {


### PR DESCRIPTION
修改数据场景，从服务端获取时间后修改 DatetimePicker v-model 绑定的值，弹出的日期时间组件无法更新，仍然是初始化时使用的时间。