### PR TITLE
解决多列选择器，当第一列选择第二个，第二列选择到最后，然后选择第一列第一个后，第二列无法选择，解决 选择器在支付宝小程序全部横向排列问题,…

### DIFF
--- a/uni_modules/uview-ui/components/u-picker/u-picker.vue
+++ b/uni_modules/uview-ui/components/u-picker/u-picker.vue
@@ -29,7 +29,7 @@
 					:key="index"
 					class="u-picker__view__column"
 				>
-					<text
+					<view
 						v-if="$u.test.array(item)"
 						class="u-picker__view__column__item u-line-1"
 						v-for="(item1, index1) in item"
@@ -39,7 +39,7 @@
 							lineHeight: $u.addUnit(itemHeight),
 							fontWeight: index1 === innerIndex[index] ? 'bold' : 'normal'
 						}"
-					>{{ getItemText(item1) }}</text>
+					>{{ getItemText(item1) }}</view>
 				</picker-view-column>
 			</picker-view>
 			<view
@@ -197,7 +197,7 @@ export default {
 				}
 			}
 			// 一次性赋值，不能单个修改，否则无效
-			this.setIndexs(tmpIndex)
+			this.setIndexs(tmpIndex, true)
 		},
 		// 获取对应列的所有选项
 		getColumnValues(columnIndex) {


### PR DESCRIPTION
解决多列选择器，当第一列选择第二个，第二列选择到最后，然后选择第一列第一个后，第二列无法选择，解决 选择器在支付宝小程序全部横向排列问题,text换成view标签