### PR TITLE
feat: 调整form-iteme下u-form-item__body__left的marginBottom取值

### DIFF
--- a/uni_modules/uview-ui/components/u-form-item/u-form-item.vue
+++ b/uni_modules/uview-ui/components/u-form-item/u-form-item.vue
@@ -15,7 +15,7 @@
 					v-if="required || leftIcon || label"
 					:style="{
 						width: $u.addUnit(labelWidth || parentData.labelWidth),
-						marginBottom: parentData.labelPosition === 'left' ? 0 : '5px',
+						marginBottom: (labelPosition || parentData.labelPosition) === 'left' ? 0 : '5px',
 					}"
 				>
 					<!-- 为了块对齐 -->


### PR DESCRIPTION
调整form-iteme下，u-form-item__body__left的marginBottom设置规则
解决当form的labelPosition，和form-item的labelPosition不一致时，可能导致其展示出一个意外的margin-bottom的问题