### PR TITLE
修改 Keyboard 键盘自定义样式无效的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-keyboard/props.js
+++ b/uni_modules/uview-ui/components/u-keyboard/props.js
@@ -79,6 +79,11 @@ export default {
         autoChange: {
             type: Boolean,
             default: uni.$u.props.keyboard.autoChange
+        },
+        // 自定义样式，对象形式
+        customStyle: {
+            type: Object,
+            default: () => { return {} }
         }
     }
 }

--- a/uni_modules/uview-ui/components/u-keyboard/u-keyboard.vue
+++ b/uni_modules/uview-ui/components/u-keyboard/u-keyboard.vue
@@ -8,9 +8,7 @@
 	    :safeAreaInsetBottom="safeAreaInsetBottom"
 	    @close="popupClose"
 	    :zIndex="zIndex"
-	    :customStyle="{
-			backgroundColor: 'rgb(214, 218, 220)'
-		}"
+	    :customStyle="customStyle"
 	>
 		<view class="u-keyboard">
 			<slot />


### PR DESCRIPTION
当前Keyboard 键盘有自定义样式的功能；
但设置后无效， 查看代码发现 customStyle 没有添加到props 也没有在页面里引用、
修改源码后生效
