### PR TITLE
feat: 为popup调用时留出的底部安全距离单独设置 class

### DIFF
--- a/uni_modules/uview-ui/components/u-popup/props.js
+++ b/uni_modules/uview-ui/components/u-popup/props.js
@@ -45,6 +45,11 @@ export default {
             type: Boolean,
             default: uni.$u.props.popup.safeAreaInsetBottom
         },
+        // 为iPhoneX留出的底部安全距离设置 class
+        safeAreaInsetBottomCustomClass: {
+            type: Boolean,
+            default: uni.$u.props.popup.safeAreaInsetBottomCustomClass,
+        },
         // 是否留出顶部安全距离（状态栏高度）
         safeAreaInsetTop: {
             type: Boolean,

--- a/uni_modules/uview-ui/components/u-popup/u-popup.vue
+++ b/uni_modules/uview-ui/components/u-popup/u-popup.vue
@@ -38,7 +38,7 @@
 						bold
 					></u-icon>
 				</view>
-				<u-safe-bottom v-if="safeAreaInsetBottom"></u-safe-bottom>
+				<u-safe-bottom v-if="safeAreaInsetBottom" :custom-class="safeAreaInsetBottomCustomClass"></u-safe-bottom>
 			</view>
 		</u-transition>
 	</view>
@@ -62,6 +62,7 @@
 	 * @property {Boolean}			closeOnClickOverlay	点击遮罩是否关闭弹窗 （默认  true ）
 	 * @property {String | Number}	zIndex				层级 （默认 10075 ）
 	 * @property {Boolean}			safeAreaInsetBottom	是否为iPhoneX留出底部安全距离 （默认 true ）
+	 * @property {String | Object} 	safeAreaInsetBottomCustomClass	为iPhoneX留出的底部安全距离设置 class
 	 * @property {Boolean}			safeAreaInsetTop	是否留出顶部安全距离（状态栏高度） （默认 false ）
 	 * @property {String}			closeIconPos		自定义关闭图标位置（默认 'top-right' ）
 	 * @property {String | Number}	round				圆角值（默认 0）

--- a/uni_modules/uview-ui/components/u-safe-bottom/u-safe-bottom.vue
+++ b/uni_modules/uview-ui/components/u-safe-bottom/u-safe-bottom.vue
@@ -2,7 +2,7 @@
 	<view
 		class="u-safe-bottom"
 		:style="[style]"
-		:class="[!isNvue && 'u-safe-area-inset-bottom']"
+		:class="[!isNvue && 'u-safe-area-inset-bottom', customClass]"
 	>
 	</view>
 </template>

--- a/uni_modules/uview-ui/libs/config/props/popup.js
+++ b/uni_modules/uview-ui/libs/config/props/popup.js
@@ -19,6 +19,7 @@ export default {
         closeOnClickOverlay: true,
         zIndex: 10075,
         safeAreaInsetBottom: true,
+        safeAreaInsetBottomCustomClass: '',
         safeAreaInsetTop: false,
         closeIconPos: 'top-right',
         round: 0,


### PR DESCRIPTION
这个PR的目的是为弹出式菜单（popup）添加一个新功能
即单独设置底部的安全距离组件的class。
开发人员可以根据需要灵活地单独设置底部安全距离组件的样式。