### PR TITLE
fix:修复头条系列焦点聚焦的时候获取不到键盘高度

### DIFF
--- a/uni_modules/uview-ui/components/u-input/u-input.vue
+++ b/uni_modules/uview-ui/components/u-input/u-input.vue
@@ -236,7 +236,7 @@ export default {
         // 输入框聚焦时触发
         onFocus(event) {
             this.focused = true;
-            this.$emit("focus");
+            this.$emit("focus",event);
         },
         // 点击完成按钮时触发
         onConfirm(event) {


### PR DESCRIPTION
抖音小程序focus时候获取不到返回高度,因为在emit focus事件的时候没有传参导致的