### PR TITLE
feat: 增加是否打印库信息开关

### DIFF
--- a/uni_modules/uview-ui/index.js
+++ b/uni_modules/uview-ui/index.js
@@ -25,7 +25,7 @@ import throttle from './libs/function/throttle.js'
 import index from './libs/function/index.js'
 
 // 配置信息
-import config from './libs/config/config.js'
+import config, { showUviewInfo } from './libs/config/config.js'
 // props配置信息
 import props from './libs/config/props.js'
 // 各个需要fixed的地方的z-index配置文件
@@ -60,7 +60,11 @@ const $u = {
 // $u挂载到uni对象上
 uni.$u = $u
 
-const install = (Vue) => {
+const install = (Vue, options) => {
+    const { showUviewLog = true } = options || {}
+
+    // 可取消打印 uview 信息
+    showUviewLog && showUviewInfo()
     // 时间格式化，同时两个名称，date和timeFormat
     Vue.filter('timeFormat', (timestamp, format) => uni.$u.timeFormat(timestamp, format))
     Vue.filter('date', (timestamp, format) => uni.$u.timeFormat(timestamp, format))

--- a/uni_modules/uview-ui/libs/config/config.js
+++ b/uni_modules/uview-ui/libs/config/config.js
@@ -1,10 +1,15 @@
 // 此版本发布于2023-03-27
 const version = '2.0.36'
 
-// 开发环境才提示，生产环境不会提示
-if (process.env.NODE_ENV === 'development') {
-	console.log(`\n %c uView V${version} %c https://uviewui.com/ \n\n`, 'color: #ffffff; background: #3c9cff; padding:5px 0; border-radius: 5px;');
-}
+export const showUviewInfo = () => {
+    // 开发环境才提示，生产环境不会提示
+    if (process.env.NODE_ENV === "development") {
+        console.log(
+            `\n %c uView V${version} %c https://uviewui.com/ \n\n`,
+            "color: #ffffff; background: #3c9cff; padding:5px 0; border-radius: 5px;"
+        );
+    }
+};
 
 export default {
     v: version,


### PR DESCRIPTION

## 本 PR 增加了一个配置项，用于控制是否打印库信息。
在hbuilder的控制台中, console.log的配置参数不生效, 影响查看信息

![image](https://user-images.githubusercontent.com/26427785/236596715-053a974d-4928-472a-b2d4-c13841ef1948.png)


## 修改内容

1. 将`config.js`打印信息的逻辑封装导出了一个`showUviewInfo`函数
2. 在install时增加了一个options配置项，当 `options.showUviewLog` 为 `true` 时才调用打印库信息。

