### PR TITLE
fix: 修复u-tabs在nvue下初始化滑块闪烁问题

### DIFF
--- a/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
+++ b/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
@@ -49,6 +49,7 @@
 							class="u-tabs__wrapper__nav__line"
 							ref="u-tabs__wrapper__nav__line"
 							:style="[{
+									transform: `scale(${ firstTime ? 0 :  1 })`,
 									width: $u.addUnit(lineWidth),
 									height: $u.addUnit(lineHeight),
 									background: lineColor,


### PR DESCRIPTION
在nvue下设置初始激活索引不为0时，滑块会从左边闪到激活tab下