### PR TITLE
fix: u-textarea的cursorSpacing属性只支持Number类型问题

### DIFF
--- a/uni_modules/uview-ui/components/u-textarea/props.js
+++ b/uni_modules/uview-ui/components/u-textarea/props.js
@@ -57,7 +57,7 @@ export default {
 		},
 		// 指定光标与键盘的距离
 		cursorSpacing: {
-			type: Number,
+			type: [String, Number],
 			default: uni.$u.props.textarea.cursorSpacing
 		},
 		// 指定focus时的光标位置


### PR DESCRIPTION
u-textarea组件cursorSpacing属性只支持Number类型，修改和u-input一样支持String类型和Number类型