### PR TITLE
修复u-tabs设置默认索引时同时设置了点击激活样式不生效的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
+++ b/uni_modules/uview-ui/components/u-tabs/u-tabs.vue
@@ -137,9 +137,7 @@
 				return index => {
 					const style = {}
 					// 取当期是否激活的样式
-					const customeStyle = index === this.innerCurrent ? uni.$u.addStyle(this.activeStyle) : uni.$u
-						.addStyle(
-							this.inactiveStyle)
+					const customeStyle = index == this.innerCurrent ? uni.$u.addStyle(this.activeStyle) : uni.$u.addStyle(this.inactiveStyle)
 					// 如果当前菜单被禁用，则加上对应颜色，需要在此做处理，是因为nvue下，无法在style样式中通过!import覆盖标签的内联样式
 					if (this.list[index].disabled) {
 						style.color = '#c8c9cc'


### PR DESCRIPTION
![image](https://github.com/umicro/uView2.0/assets/58896251/4f27c572-6e12-4be3-b304-6f9ddc16c34c)
当设置了current时同时设置了activeStyle样式时进入页面时activeStyleactiveStyle的样式未生效
