### PR TITLE
fix: 修复square属性在小程序open-data下无效问题

### DIFF
--- a/uni_modules/uview-ui/components/u-avatar/u-avatar.vue
+++ b/uni_modules/uview-ui/components/u-avatar/u-avatar.vue
@@ -162,6 +162,7 @@
 		&__image {
 			&--circle {
 				border-radius: 100px;
+				overflow: hidden;
 			}
 
 			&--square {


### PR DESCRIPTION
设置overflow:hidden，用于超出隐藏。

修复[#1027 ](https://github.com/umicro/uView2.0/issues/1027)