### PR TITLE
fix: 修复安卓微信实际输入字数超过限制问题

### DIFF
--- a/uni_modules/uview-ui/components/u-textarea/u-textarea.vue
+++ b/uni_modules/uview-ui/components/u-textarea/u-textarea.vue
@@ -164,6 +164,9 @@ export default {
         },
         onInput(e) {
 			let { value = "" } = e.detail || {};
+			if (this.maxlength > 0 && value.length > this.maxlength) {
+				value = value.subtring(0, this.maxlength);
+			}
 			// 格式化过滤方法
 			const formatter = this.formatter || this.innerFormatter
 			const formatValue = formatter(value)


### PR DESCRIPTION
在安卓微信中输入，达到最大长度后继续输入，虽然输入框内不会看到超出的字体，实际input回调的value长度会多一个或两个