### PR TITLE
修改addUnit方法：当前单位默认是px，当修改默认单位为rpx时，组件的尺寸会变小一倍，与预期不符；

### DIFF
--- a/uni_modules/uview-ui/libs/function/index.js
+++ b/uni_modules/uview-ui/libs/function/index.js
@@ -173,7 +173,7 @@ function addStyle(customStyle, target = 'object') {
 function addUnit(value = 'auto', unit = uni?.$u?.config?.unit ?? 'px') {
 	value = String(value)
 	// 用uView内置验证规则中的number判断是否为数值
-	return test.number(value) ? `${value}${unit}` : value
+    return test.number(value) ? `${unit==='rpx' ? value * 2 : value}${unit}` : value
 }
 
 /**


### PR DESCRIPTION
修改addUnit方法：
当前单位默认是px，当修改默认单位为rpx时，组件的尺寸会变小一倍，与预期不符；
为保持修改默认单位后的尺寸保持一致，故添加unit参数判断，当unit入参为rpx时，value*2处理，以达到修改默认单位不影响组件尺寸。