### PR TITLE
fix(u-tooltip):修复size不生效的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-tooltip/u-tooltip.vue
+++ b/uni_modules/uview-ui/components/u-tooltip/u-tooltip.vue
@@ -18,6 +18,7 @@
 				@longpress.stop="longpressHandler"
 				:style="{
 					color: color,
+					fontSize: $u.addUnit(size),
 					backgroundColor: bgColor && showTooltip && tooltipTop !== -10000 ? bgColor : 'transparent'
 				}"
 			>{{ text }}</text>


### PR DESCRIPTION
u-tooltip组件size参数没应用到text样式，修复size不生效的问题。
style增加`fontSize: $u.addUnit(size),`
