### PR TITLE
修复v-form在调用validate时promise有大几率一直pending状态

### DIFF
--- a/uni_modules/uview-ui/components/u-form/u-form.vue
+++ b/uni_modules/uview-ui/components/u-form/u-form.vue
@@ -124,7 +124,7 @@
 			// 对部分表单字段进行校验
 			async validateField(value, callback, event = null) {
 				// $nextTick是必须的，否则model的变更，可能会延后于此方法的执行
-				this.$nextTick(() => {
+				//this.$nextTick(() => {
 					// 校验错误信息，返回给回调方法，用于存放所有form-item的错误信息
 					const errorsRes = [];
 					// 如果为字符串，转为数组
@@ -178,7 +178,7 @@
 					});
 					// 执行回调函数
 					typeof callback === "function" && callback(errorsRes);
-				});
+				//});
 			},
 			// 校验全部数据
 			validate(callback) {


### PR DESCRIPTION
BUG效果：this.$refs.form.validate(); 经常无反应，既没有then也没有catch，首次可以，二次之后就经常要执行多次才有效果，反复无常


问题点：
源码简化后的代码就是两层$nextTick，即如下：
this.$nextTick(() => {
.....this.$nextTick(() => {
..........在没有更新新数据时，这里不会执行（这里放着promise的resolve和reject，不执行那肯定是pending），删掉第二层重复的$nextTick即可解决
.....})
 });

因为要等2次队列更新，所以第一次更新数据后进入this.validateField，第二层里面的nextTick就大概率不会再执行了，那么promise就一直是pending。那么只需要删除第二层的nextTick即可解决
