### PR TITLE
修复u-number-box删除最后一位数字后 再次focus再次删除时值为空的问题 导致和v-model值不一致的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-number-box/u-number-box.vue
+++ b/uni_modules/uview-ui/components/u-number-box/u-number-box.vue
@@ -249,6 +249,13 @@
 			onBlur(event) {
 				// 对输入值进行格式化
 				const value = this.format(event.detail.value)
+				if(value !== this.currentValue){
+					//如果输入的值为空需要将值修改为最小值
+					if(this.currentValue === ''){
+						this.currentValue = value;
+					}
+					this.emitChange(value);
+				}
 				// 发出blur事件
 				this.$emit(
 					'blur',{


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fd7fbe1e-8e6b-4cc4-89dc-ed6515c4bb0c)

修复手动删除最后一位数字后，input内值为空，但是实际v-model有值的bug。在blur事件内将值修改为最小值。触发onchange事件