### PR TITLE
fix: 修复u-transition在非H5端的动画异常问题；同时解决Popup组件Modal组件，进入动画丢失的问题

### DIFF
--- a/uni_modules/uview-ui/components/u-transition/transition.js
+++ b/uni_modules/uview-ui/components/u-transition/transition.js
@@ -1,4 +1,4 @@
-// 定义一个一定时间后自动成功的promise，让调用nextTick方法处，进入下一个then方法
+﻿// 定义一个一定时间后自动成功的promise，让调用nextTick方法处，进入下一个then方法
 const nextTick = () => new Promise(resolve => setTimeout(resolve, 1000 / 50))
 // nvue动画模块实现细节抽离在外部文件
 import animationMap from './nvue.ani-map.js'
@@ -38,9 +38,7 @@ export default {
             this.display = true
             this.classes = classNames.enter
             this.$nextTick(async () => {
-				// #ifdef H5
-				await uni.$u.sleep(20)
-				// #endif
+				await uni.$u.sleep(20) // 确保渲染完成
                 // 标识动画尚未结束
                 this.$emit('enter')
                 this.transitionEnded = false


### PR DESCRIPTION
# BUG效果：开发小程序使用u-popup时，发现弹窗很大几率不执行动画瞬间弹出。查看官方小程序示例后发现存在同样问题。

# 问题点：
![pr3](https://github.com/user-attachments/assets/bb66d100-627a-4cad-b1ce-8dd0871debaf)
![pr4](https://github.com/user-attachments/assets/efc4091f-f5d1-4a0a-a190-8e6ce88cb6f0)

发现是这里wwww2输出的是Vue 组件实例的详细信息，而非 DOM 元素，请教下动画不执行的具体原因解释，感谢

# 修复后，动画丢失情况未复现

# Related Issues
close #416 
close #545 

