### PR TITLE
允许Form表单设置model为空对象

### DIFF
--- a/uni_modules/uview-ui/components/u-form/u-form.vue
+++ b/uni_modules/uview-ui/components/u-form/u-form.vue
@@ -90,7 +90,7 @@
 			setRules(rules) {
 				// 判断是否有规则
 				if (Object.keys(rules).length === 0) return;
-				if (process.env.NODE_ENV === 'development' && Object.keys(this.model).length === 0) {
+				if (process.env.NODE_ENV === 'development' && !(typeof this.model === 'object' || Object.prototype.toString.call(this.model) === '[object Object]')) {
 					uni.$u.error('设置rules，model必须设置！如果已经设置，请刷新页面。');
 					return;
 				};
@@ -212,3 +212,4 @@
 
 <style lang="scss" scoped>
 </style>
+


### PR DESCRIPTION
避免设置了空对象，仍然会报错